### PR TITLE
Feat/proxy UI twitch events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ dist-ssr
 .env
 .vscode
 package-lock.json
+
+# Local OAuth tokens
+server/.twitch-auth.json
+
+# Local custom fonts (optional)
+public/fonts/

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ This project can also show Twitch “events” (not chat) like channel point red
    ```
    This runs the server + Vite on HTTPS (Twitch requires HTTPS redirect URLs). You may need to accept the browser’s local certificate warning once.
 2. Create a Twitch Developer app and copy its **Client ID**.
-   - If Twitch requires a **Client Secret** for your app type, you can paste it in Settings during authentication (it’s only used for the token exchange, then discarded from the browser storage).
-   - Scopes used: `channel:read:redemptions` (channel points) and `channel:read:raids` (raids).
+   - If Twitch requires a **Client Secret** for your app type, paste it in Settings during authentication. It is not stored in the browser settings, but the local server may store it in `server/.twitch-auth.json` so it can refresh tokens.
+   - Default OAuth scope: `channel:read:redemptions` (channel points). You can optionally add `channel:read:raids` if Twitch accepts it for your app; raids also show as chat alerts regardless.
 3. Add this redirect URL to the app:
    - `https://localhost:5173/auth/twitch`
 4. In the app Settings, enable **Twitch Events**, paste Client ID, and click **Authenticate**.
+5. If Twitch rejects a scope (example: `invalid scope requested: 'channel:read:raids'`), remove it from **Requested OAuth Scopes** and re-authenticate. (Raids will still show as chat alerts.)
 
 ### Optional Fonts (Pirulen / Vandav)
 
@@ -119,6 +120,7 @@ They are gitignored by default.
 4. **URL Params (optional)**:
    - `?twitch=channel&kick=channel&youtube_vid=VIDEO_ID&theme=dark`
    - Twitch events params (optional): `twitch_events=true&twitch_client=CLIENT_ID&twitch_system=NAME`
+   - Twitch events scopes override (optional): `twitch_scopes=channel:read:redemptions` (optionally add `%20channel:read:raids` if Twitch accepts it)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This project can also show Twitch “events” (not chat) like channel point red
    This runs the server + Vite on HTTPS (Twitch requires HTTPS redirect URLs). You may need to accept the browser’s local certificate warning once.
 2. Create a Twitch Developer app and copy its **Client ID**.
    - If Twitch requires a **Client Secret** for your app type, you can paste it in Settings during authentication (it’s only used for the token exchange, then discarded from the browser storage).
+   - Scopes used: `channel:read:redemptions` (channel points) and `channel:read:raids` (raids).
 3. Add this redirect URL to the app:
    - `https://localhost:5173/auth/twitch`
 4. In the app Settings, enable **Twitch Events**, paste Client ID, and click **Authenticate**.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chat Aggregator
 
-A lightweight, responsive web application for aggregating live chat messages from Twitch, YouTube, and Kick in real-time. Built with Vue.js and Vite, it features a full-width chat display, custom color palette, and low memory usage (~200-300 MB). Ideal for streamers, with configuration via URL query parameters and automatic startup.
+A cyberpunk-styled, lightweight chat “popout” for aggregating live chat messages from Twitch, YouTube, and Kick. It includes an in-app Settings modal (saved to `localStorage`) and an optional local server for YouTube (no API key) and Twitch EventSub (channel points / raids).
 
 ## Features
 
@@ -8,32 +8,32 @@ A lightweight, responsive web application for aggregating live chat messages fro
   - Twitch: Real-time messages via `tmi.js` (IRC WebSockets).
   - YouTube: Polling-based messages via YouTube Data API v3.
   - Kick: Real-time messages via Pusher WebSockets.
-- **URL Query Parameter Configuration**:
-  - Auto-load channel settings with `?twitch=channel&kick=channel&youtube_vid=videoid`.
-  - Set theme with `?theme=dark` or `?theme=light`.
-- **Automatic Startup**: Services start automatically when valid query parameters are provided.
-- **Hidden Settings UI**: Configuration is done via URL; no visible settings form.
+- **In-App Settings**:
+  - Opens automatically when no configuration is saved.
+  - Saved to `localStorage` and auto-starts on reload.
+  - Still supports URL query params (optional).
+- **Chat Composer**: Local “test messages” input (not sent to platforms), with `/settings` and `/clear`.
 - **Responsive Design**: Full-width chat display, mobile-friendly.
-- **Custom Theme**: Elegant color palette (`#123a49`, `#2da592`, `#8bcbb7`, `#f5faf6`) with light/dark mode support.
+- **Cyberpunk Theme**: Glassy dark purples + neon orange accents; optional local fonts (Pirulen/Vandav).
 - **Remixicon Icons**: Platform-specific icons (Twitch, YouTube, Kick).
-- **Optimized Performance**:
-  - Memory capped at ~200-300 MB by limiting messages (100 stored, 50 displayed).
-  - Cleaned-up event listeners for Pusher and `tmi.js` to prevent memory leaks.
-  - YouTube polling set to 2 seconds to balance speed and API quota.
-- **Secure Configuration**: YouTube API key stored in `.env`.
+- **Twitch Events (optional)**: Channel points + raids via Twitch EventSub (requires OAuth login).
 
 ## Prerequisites
 
 - **Node.js**: Version 18 or higher.
 - **npm**: Version 8 or higher.
-- **YouTube API Key**: Obtain from [Google Cloud Console](https://console.cloud.google.com/) with YouTube Data API v3 enabled.
+- **YouTube Chat (choose one)**:
+  - **Recommended (official)**: YouTube Data API v3 key (requires a Google Cloud project).
+  - **No-key (local proxy)**: Uses `youtube-chat` (unofficial) via a small local Node server.
+- **Twitch Events (optional)**:
+  - To capture channel points + raids, you need a Twitch Developer App **Client ID** and a one-time OAuth login.
 - **Live Channels**: Access to live Twitch, YouTube, and Kick channels for testing.
 
 ## Installation
 
 1. **Clone the Repository**:
    ```bash
-   git clone https://github.com/yourusername/chat-aggregator.git
+   git clone https://github.com/bertugfahriozer/chat-aggregator.git
    cd chat-aggregator
    ```
 
@@ -42,32 +42,72 @@ A lightweight, responsive web application for aggregating live chat messages fro
    npm install
    ```
 
-3. **Set Up Environment Variables**:
-   - Create a `.env` file in the project root:
-     ```env
-     VITE_YOUTUBE_API_KEY=your_youtube_api_key_here
-     ```
-   - Replace `your_youtube_api_key_here` with your YouTube Data API key.
+3. **Set Up YouTube (pick one)**:
+   - **Option A: With a YouTube API key (official)**
+     - Create a `.env` file in the project root:
+       ```env
+       VITE_YOUTUBE_API_KEY=your_youtube_api_key_here
+       ```
+   - **Option B: Without a YouTube API key (local proxy)**
+     - No `.env` needed.
+     - You will run the local proxy with `npm run dev:yt` (see below).
 
 4. **Run the Development Server**:
    ```bash
    npm run dev
    ```
-   - Open the app at `http://localhost:5173?twitch=yourchannel&kick=yourchannel&youtube_vid=yourvideoid&theme=dark`.
+   - Open the app at `http://localhost:5173` and use the Settings button.
+
+### Getting a YouTube API Key (Official)
+
+1. Open Google Cloud Console: `https://console.cloud.google.com/`
+2. Create/select a project.
+3. Enable **YouTube Data API v3** for the project.
+4. Create an **API key** under **APIs & Services → Credentials**.
+5. Put it into `.env` as `VITE_YOUTUBE_API_KEY=...`.
+
+## Running YouTube Without an API Key (Local Proxy)
+
+If you don’t want to set up a YouTube Data API key, you can run the included proxy server:
+
+```bash
+npm run dev:yt
+```
+
+- The local server listens on `http://localhost:4174` and the Vite dev server proxies `/api/*` requests to it.
+- Configure YouTube via Settings (or `?youtube_vid=VIDEO_ID`).
+
+If you deploy the frontend separately, set `VITE_YOUTUBE_PROXY_URL` to your proxy origin (example: `http://localhost:4174`).
+
+## Twitch Events (Channel Points + Raids)
+
+This project can also show Twitch “events” (not chat) like channel point redemptions and raids via EventSub (WebSocket).
+
+1. Run the local server (required):
+   ```bash
+   npm run dev:all:https
+   ```
+   This runs the server + Vite on HTTPS (Twitch requires HTTPS redirect URLs). You may need to accept the browser’s local certificate warning once.
+2. Create a Twitch Developer app and copy its **Client ID**.
+   - If Twitch requires a **Client Secret** for your app type, you can paste it in Settings during authentication (it’s only used for the token exchange, then discarded from the browser storage).
+3. Add this redirect URL to the app:
+   - `https://localhost:5173/auth/twitch`
+4. In the app Settings, enable **Twitch Events**, paste Client ID, and click **Authenticate**.
+
+### Optional Fonts (Pirulen / Vandav)
+
+If you have local copies of Pirulen/Vandav, place them at:
+
+- `chat-aggregator/public/fonts/PirulenRg.otf`
+- `chat-aggregator/public/fonts/Vandav.ttf`
+
+They are gitignored by default.
 
 ## Usage
 
-1. **Configure via URL**:
-   - Use query parameters to set channels and theme, e.g.:
-     ```
-     http://localhost:5173?twitch=bertugfahriozer&kick=bertugfahriozer&youtube_vid=QWsdserc&theme=dark
-     ```
-   - Parameters:
-     - `twitch`: Twitch channel name (e.g., `bertugfahriozer`).
-     - `youtube_vid`: YouTube live video ID (e.g., `QWsdserc`).
-     - `kick`: Kick channel slug (e.g., `bertugfahriozer`).
-     - `theme`: `dark` or `light` (defaults to system `prefers-color-scheme`).
-   - The app auto-starts with the specified channels and theme.
+1. **Configure in Settings**:
+   - Click **Settings** → enter channels/video ID → **Start**.
+   - Settings are saved and auto-start next load.
 
 2. **View Chats**:
    - Messages from Twitch, YouTube, and Kick appear in real-time with platform-specific icons and colors (Twitch: purple, YouTube: red, Kick: green).
@@ -75,12 +115,17 @@ A lightweight, responsive web application for aggregating live chat messages fro
 3. **Toggle Theme**:
    - Use the theme toggle button in the header to switch between light and dark modes manually.
 
+4. **URL Params (optional)**:
+   - `?twitch=channel&kick=channel&youtube_vid=VIDEO_ID&theme=dark`
+   - Twitch events params (optional): `twitch_events=true&twitch_client=CLIENT_ID&twitch_system=NAME`
+
 ## Project Structure
 
 ```
 chat-aggregator/
 ├── public/
 │   ├── vite.svg
+│   ├── fonts/                 # Optional local fonts (gitignored)
 ├── src/
 │   ├── assets/
 │   │   ├── vue.svg
@@ -92,11 +137,15 @@ chat-aggregator/
 │   │   ├── kickService.js        # Kick chat via Pusher
 │   │   ├── twitchService.js      # Twitch chat via tmi.js
 │   │   ├── youtubeService.js     # YouTube chat via API polling
+│   │   ├── youtubeProxyService.js # YouTube chat via local proxy (no API key)
+│   │   ├── twitchEventProxyService.js # Twitch events via local proxy (EventSub)
 │   ├── store/
 │   │   ├── index.js              # Vuex store for state management
 │   ├── App.vue                   # Main app with chat layout
 │   ├── main.js                   # Entry point
 │   ├── style.css                 # Global styles with color palette
+├── server/
+│   ├── index.js                  # Local proxy (YouTube + Twitch EventSub)
 ├── .env                          # Environment variables (not committed)
 ├── .gitignore                    # Git ignore file
 ├── index.html                    # HTML entry with Inter font and Remixicon
@@ -125,16 +174,16 @@ chat-aggregator/
 ## Troubleshooting
 
 - **YouTube Messages Not Appearing**:
-  - Check `.env` for a valid `VITE_YOUTUBE_API_KEY`.
   - Ensure `youtube_vid` is for a live stream.
-  - Look for `YouTube Polling Error` in the console.
+  - If using an API key: check `.env` for a valid `VITE_YOUTUBE_API_KEY` and look for `YouTube API Polling Error` in the console.
+  - If using the no-key proxy: run `npm run dev:yt` and check the terminal for proxy errors.
 - **High RAM Usage**:
   - Use Chrome DevTools > Memory to take heap snapshots.
   - Reduce `maxMessages` in `store/index.js` to 50 if needed.
 - **Kick Icon Missing**:
   - If `ri-kick-fill` is unavailable, replace with `ri-chat-3-fill` in `ChatDisplay.vue`.
 - **No Messages Without Query Parameters**:
-  - The app requires valid `twitch`, `youtube_vid`, or `kick` parameters to start.
+  - Use **Settings** (it opens automatically on first run).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:https": "HTTPS=1 vite",
+    "server": "node server/index.js",
+    "dev:all": "concurrently -k \"npm run server\" \"npm run dev\"",
+    "dev:all:https": "concurrently -k \"npm run server\" \"npm run dev:https\"",
+    "dev:yt": "concurrently -k \"npm run server\" \"npm run dev\"",
     "build": "vite build",
     "preview": "vite preview"
   },
@@ -15,10 +20,13 @@
     "vue": "^3.5.18",
     "vuex": "^4.1.0",
     "uuid": "^10.0.0",
-    "remixicon": "^4.4.0"
+    "remixicon": "^4.4.0",
+    "youtube-chat": "^2.2.0"
   },
   "devDependencies": {
+    "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-vue": "^6.0.1",
+    "concurrently": "^9.2.1",
     "vite": "^7.1.2"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -91,6 +91,15 @@ class TwitchEventSub {
     this.auth = null;
     this.reconnectTimer = null;
     this.reconnectAttempt = 0;
+    this.shouldReconnect = false;
+    this.lastRefreshFailureAt = 0;
+  }
+
+  disableReconnect() {
+    this.shouldReconnect = false;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.reconnectAttempt = 0;
   }
 
   getStatus() {
@@ -101,6 +110,7 @@ class TwitchEventSub {
       scopes: this.auth?.scope || [],
       expiresAt: this.auth?.expiresAt || null,
       hasAuth: Boolean(this.auth?.accessToken),
+      refreshConfigured: Boolean(this.auth?.refreshToken && this.auth?.clientSecret),
     };
   }
 
@@ -110,11 +120,9 @@ class TwitchEventSub {
   }
 
   stop() {
+    this.disableReconnect();
     this.connected = false;
     this.sessionId = null;
-    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
-    this.reconnectTimer = null;
-    this.reconnectAttempt = 0;
     this.closeWs();
   }
 
@@ -128,6 +136,8 @@ class TwitchEventSub {
   }
 
   scheduleReconnect(reason) {
+    if (!this.shouldReconnect) return;
+    if (!this.auth?.accessToken || !this.auth?.clientId) return;
     if (this.reconnectTimer) return;
     const backoffMs = Math.min(30000, 1000 * 2 ** this.reconnectAttempt);
     this.reconnectAttempt += 1;
@@ -146,11 +156,14 @@ class TwitchEventSub {
   }
 
   async ensureValidToken() {
-    if (!this.auth?.accessToken || !this.auth?.clientId) return;
+    if (!this.auth?.accessToken || !this.auth?.clientId) return false;
 
     const now = Date.now();
     if (this.auth.expiresAt && this.auth.expiresAt - now < 60_000 && this.auth.refreshToken) {
-      await this.refreshToken();
+      const recentlyFailed = this.lastRefreshFailureAt && now - this.lastRefreshFailureAt < 5 * 60_000;
+      if (!recentlyFailed) {
+        await this.refreshToken();
+      }
     }
 
     const validateRes = await fetch("https://id.twitch.tv/oauth2/validate", {
@@ -164,18 +177,25 @@ class TwitchEventSub {
         status: "auth_invalid",
         error: `validate_failed:${validateRes.status}`,
       });
-      return;
+      if (validateRes.status === 401 || validateRes.status === 403) {
+        this.disableReconnect();
+        this.closeWs();
+      }
+      return false;
     }
 
     const validated = await validateRes.json();
+    const expiresIn = Number(validated.expires_in);
     const updated = {
       ...this.auth,
       userId: validated.user_id,
       login: validated.login,
       scope: Array.isArray(validated.scopes) ? validated.scopes : [],
+      expiresAt: Number.isFinite(expiresIn) ? Date.now() + expiresIn * 1000 : this.auth.expiresAt,
     };
     this.auth = updated;
     await this.onAuthUpdate(updated);
+    return true;
   }
 
   async refreshToken() {
@@ -187,6 +207,10 @@ class TwitchEventSub {
       client_id: this.auth.clientId,
     });
 
+    if (this.auth.clientSecret) {
+      body.set("client_secret", this.auth.clientSecret);
+    }
+
     const res = await fetch("https://id.twitch.tv/oauth2/token", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -194,7 +218,12 @@ class TwitchEventSub {
     });
 
     if (!res.ok) {
-      this.broadcastStatus({ status: "auth_refresh_failed", error: `refresh_failed:${res.status}` });
+      this.lastRefreshFailureAt = Date.now();
+      const errText = await res.text();
+      this.broadcastStatus({
+        status: "auth_refresh_failed",
+        error: `refresh_failed:${res.status}:${errText?.slice?.(0, 250) || ""}`,
+      });
       return;
     }
 
@@ -214,42 +243,50 @@ class TwitchEventSub {
     this.broadcastStatus({ status: "auth_refreshed" });
   }
 
-  async connect() {
+  async connect(wsUrl = "wss://eventsub.wss.twitch.tv/ws") {
+    this.shouldReconnect = true;
     if (!this.auth?.accessToken || !this.auth?.clientId) {
       this.broadcastStatus({ status: "auth_required" });
       return;
     }
 
-    await this.ensureValidToken();
+    const tokenOk = await this.ensureValidToken();
+    if (!tokenOk) return;
     if (!this.auth?.userId) {
       this.broadcastStatus({ status: "auth_required" });
       return;
     }
 
+    this.connected = false;
+    this.sessionId = null;
     this.closeWs();
     this.broadcastStatus({ status: "connecting" });
 
-    const ws = new WebSocket("wss://eventsub.wss.twitch.tv/ws");
+    const ws = new WebSocket(wsUrl);
     this.ws = ws;
 
     ws.addEventListener("open", () => {
+      if (ws !== this.ws) return;
       this.connected = true;
       this.reconnectAttempt = 0;
       this.broadcastStatus({ status: "ws_open" });
     });
 
-    ws.addEventListener("close", () => {
+    ws.addEventListener("close", (ev) => {
+      if (ws !== this.ws) return;
       this.connected = false;
       this.sessionId = null;
-      this.broadcastStatus({ status: "ws_closed" });
+      this.broadcastStatus({ status: "ws_closed", code: ev?.code, reason: ev?.reason });
       this.scheduleReconnect("ws_closed");
     });
 
     ws.addEventListener("error", (err) => {
+      if (ws !== this.ws) return;
       this.broadcastStatus({ status: "ws_error", error: String(err?.message || err) });
     });
 
     ws.addEventListener("message", (event) => {
+      if (ws !== this.ws) return;
       try {
         const payload = JSON.parse(String(event.data || "{}"));
         this.handleWsMessage(payload).catch((err) => {
@@ -272,6 +309,18 @@ class TwitchEventSub {
     }
 
     if (messageType === "session_keepalive") return;
+
+    if (messageType === "session_reconnect") {
+      const reconnectUrl = message?.payload?.session?.reconnect_url || null;
+      this.broadcastStatus({ status: "session_reconnect" });
+      if (reconnectUrl) {
+        this.connect(reconnectUrl).catch((err) => {
+          this.broadcastStatus({ status: "error", error: String(err?.message || err) });
+          this.scheduleReconnect("session_reconnect_failed");
+        });
+      }
+      return;
+    }
 
     if (messageType === "notification") {
       const messageId = message?.metadata?.message_id || null;
@@ -305,23 +354,43 @@ class TwitchEventSub {
     const broadcasterUserId = this.auth?.userId;
     if (!broadcasterUserId) return;
 
-    const subscriptions = [
-      {
+    const hasScope = (scope) => (this.auth?.scope || []).includes(scope);
+
+    const subscriptions = [];
+    if (hasScope("channel:read:redemptions")) {
+      subscriptions.push({
         type: "channel.channel_points_custom_reward_redemption.add",
         version: "1",
         condition: { broadcaster_user_id: broadcasterUserId },
-      },
-      {
-        type: "channel.raid",
-        version: "1",
-        condition: { to_broadcaster_user_id: broadcasterUserId },
-      },
-      {
-        type: "channel.raid",
-        version: "1",
-        condition: { from_broadcaster_user_id: broadcasterUserId },
-      },
-    ];
+      });
+    } else {
+      this.broadcastStatus({
+        status: "subscription_skipped",
+        subscriptionType: "channel.channel_points_custom_reward_redemption.add",
+        reason: "missing_scope:channel:read:redemptions",
+      });
+    }
+
+    if (hasScope("channel:read:raids")) {
+      subscriptions.push(
+        {
+          type: "channel.raid",
+          version: "1",
+          condition: { to_broadcaster_user_id: broadcasterUserId },
+        },
+        {
+          type: "channel.raid",
+          version: "1",
+          condition: { from_broadcaster_user_id: broadcasterUserId },
+        }
+      );
+    } else {
+      this.broadcastStatus({
+        status: "subscription_skipped",
+        subscriptionType: "channel.raid",
+        reason: "missing_scope:channel:read:raids",
+      });
+    }
 
     for (const sub of subscriptions) {
       await this.createSubscription(sub).catch((err) => {
@@ -335,7 +404,8 @@ class TwitchEventSub {
   }
 
   async createSubscription({ type, version, condition }) {
-    await this.ensureValidToken();
+    const ok = await this.ensureValidToken();
+    if (!ok) return;
 
     const res = await fetch("https://api.twitch.tv/helix/eventsub/subscriptions", {
       method: "POST",
@@ -468,6 +538,7 @@ class TwitchManager {
     const token = await res.json();
     const auth = {
       clientId,
+      clientSecret: clientSecret || null,
       accessToken: token.access_token,
       refreshToken: token.refresh_token || null,
       tokenType: token.token_type,
@@ -569,6 +640,45 @@ function getRoom(liveId) {
 const twitch = new TwitchManager();
 await twitch.load();
 
+// Viewer count fetching functions
+async function fetchTwitchViewers(channel) {
+  const auth = twitch.eventSub?.auth;
+  if (!auth?.accessToken || !auth?.clientId) {
+    return null;
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.twitch.tv/helix/streams?user_login=${encodeURIComponent(channel)}`,
+      {
+        headers: {
+          "Client-Id": auth.clientId,
+          Authorization: `Bearer ${auth.accessToken}`,
+        },
+      }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    const stream = data?.data?.[0];
+    return stream?.viewer_count ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchKickViewers(channel) {
+  try {
+    const res = await fetch(`https://kick.com/api/v2/channels/${encodeURIComponent(channel)}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    // Kick returns livestream info with viewer count when live
+    const viewers = data?.livestream?.viewer_count;
+    return viewers !== undefined ? Number(viewers) : null;
+  } catch {
+    return null;
+  }
+}
+
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
@@ -591,6 +701,25 @@ const server = http.createServer(async (req, res) => {
     return sendJson(res, 200, twitch.getStatus(), {
       "Access-Control-Allow-Origin": "*",
     });
+  }
+
+  // Viewer count endpoints
+  if (req.method === "GET" && url.pathname.startsWith("/api/viewers/twitch/")) {
+    const channel = url.pathname.split("/api/viewers/twitch/")[1];
+    if (!channel) {
+      return sendJson(res, 400, { error: "Missing channel" }, { "Access-Control-Allow-Origin": "*" });
+    }
+    const viewers = await fetchTwitchViewers(decodeURIComponent(channel));
+    return sendJson(res, 200, { viewers }, { "Access-Control-Allow-Origin": "*" });
+  }
+
+  if (req.method === "GET" && url.pathname.startsWith("/api/viewers/kick/")) {
+    const channel = url.pathname.split("/api/viewers/kick/")[1];
+    if (!channel) {
+      return sendJson(res, 400, { error: "Missing channel" }, { "Access-Control-Allow-Origin": "*" });
+    }
+    const viewers = await fetchKickViewers(decodeURIComponent(channel));
+    return sendJson(res, 200, { viewers }, { "Access-Control-Allow-Origin": "*" });
   }
 
   if (req.method === "POST" && url.pathname === "/api/twitch/pkce/exchange") {

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,839 @@
+import http from "node:http";
+import fs from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import { LiveChat } from "youtube-chat";
+
+const port = Number(process.env.YOUTUBE_PROXY_PORT || process.env.PORT || 4174);
+const oauthBaseUrl = `http://localhost:${port}`;
+const twitchAuthFileUrl = new URL("./.twitch-auth.json", import.meta.url);
+
+function json(data) {
+  return JSON.stringify(data);
+}
+
+function send(res, statusCode, body, headers = {}) {
+  res.writeHead(statusCode, {
+    "Content-Type": "text/plain; charset=utf-8",
+    ...headers,
+  });
+  res.end(body);
+}
+
+function sendJson(res, statusCode, data, headers = {}) {
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    ...headers,
+  });
+  res.end(json(data));
+}
+
+async function readJsonBody(req, maxBytes = 200_000) {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      throw new Error("body_too_large");
+    }
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+function base64Url(buffer) {
+  return Buffer.from(buffer)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function sha256Base64Url(input) {
+  return base64Url(createHash("sha256").update(input).digest());
+}
+
+async function readJsonFile(url) {
+  try {
+    const raw = await fs.readFile(url, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeJsonFile(url, data) {
+  await fs.writeFile(url, json(data), "utf8");
+}
+
+async function deleteFile(url) {
+  try {
+    await fs.unlink(url);
+  } catch {
+    // ignore
+  }
+}
+
+function textFromChatItem(chatItem) {
+  if (!Array.isArray(chatItem?.message)) return "";
+  return chatItem.message
+    .map((part) => {
+      if (typeof part?.text === "string") return part.text;
+      if (typeof part?.emojiText === "string") return part.emojiText;
+      if (typeof part?.alt === "string") return part.alt;
+      return "";
+    })
+    .join("");
+}
+
+function stableId({ liveId, username, text, timestamp }) {
+  const payload = `${liveId}\n${username}\n${timestamp}\n${text}`;
+  return createHash("sha1").update(payload).digest("hex");
+}
+
+class TwitchEventSub {
+  constructor({ broadcastStatus, broadcastEvent, onAuthUpdate }) {
+    this.broadcastStatus = broadcastStatus;
+    this.broadcastEvent = broadcastEvent;
+    this.onAuthUpdate = onAuthUpdate;
+    this.ws = null;
+    this.sessionId = null;
+    this.connected = false;
+    this.auth = null;
+    this.reconnectTimer = null;
+    this.reconnectAttempt = 0;
+  }
+
+  getStatus() {
+    return {
+      connected: Boolean(this.connected && this.ws && this.ws.readyState === WebSocket.OPEN),
+      login: this.auth?.login || null,
+      userId: this.auth?.userId || null,
+      scopes: this.auth?.scope || [],
+      expiresAt: this.auth?.expiresAt || null,
+      hasAuth: Boolean(this.auth?.accessToken),
+    };
+  }
+
+  async setAuth(auth) {
+    this.auth = auth;
+    await this.ensureValidToken();
+  }
+
+  stop() {
+    this.connected = false;
+    this.sessionId = null;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.reconnectAttempt = 0;
+    this.closeWs();
+  }
+
+  closeWs() {
+    try {
+      this.ws?.close?.();
+    } catch {
+      // ignore
+    }
+    this.ws = null;
+  }
+
+  scheduleReconnect(reason) {
+    if (this.reconnectTimer) return;
+    const backoffMs = Math.min(30000, 1000 * 2 ** this.reconnectAttempt);
+    this.reconnectAttempt += 1;
+    this.broadcastStatus({
+      status: "reconnecting",
+      reason: reason || "ws_closed",
+      backoffMs,
+    });
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect().catch((err) => {
+        this.broadcastStatus({ status: "error", error: String(err?.message || err) });
+        this.scheduleReconnect("connect_failed");
+      });
+    }, backoffMs);
+  }
+
+  async ensureValidToken() {
+    if (!this.auth?.accessToken || !this.auth?.clientId) return;
+
+    const now = Date.now();
+    if (this.auth.expiresAt && this.auth.expiresAt - now < 60_000 && this.auth.refreshToken) {
+      await this.refreshToken();
+    }
+
+    const validateRes = await fetch("https://id.twitch.tv/oauth2/validate", {
+      headers: {
+        Authorization: `OAuth ${this.auth.accessToken}`,
+      },
+    });
+
+    if (!validateRes.ok) {
+      this.broadcastStatus({
+        status: "auth_invalid",
+        error: `validate_failed:${validateRes.status}`,
+      });
+      return;
+    }
+
+    const validated = await validateRes.json();
+    const updated = {
+      ...this.auth,
+      userId: validated.user_id,
+      login: validated.login,
+      scope: Array.isArray(validated.scopes) ? validated.scopes : [],
+    };
+    this.auth = updated;
+    await this.onAuthUpdate(updated);
+  }
+
+  async refreshToken() {
+    if (!this.auth?.refreshToken || !this.auth?.clientId) return;
+
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: this.auth.refreshToken,
+      client_id: this.auth.clientId,
+    });
+
+    const res = await fetch("https://id.twitch.tv/oauth2/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    if (!res.ok) {
+      this.broadcastStatus({ status: "auth_refresh_failed", error: `refresh_failed:${res.status}` });
+      return;
+    }
+
+    const token = await res.json();
+    const updated = {
+      ...this.auth,
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token || this.auth.refreshToken,
+      tokenType: token.token_type,
+      scope: token.scope || this.auth.scope || [],
+      obtainedAt: Date.now(),
+      expiresAt: Date.now() + (Number(token.expires_in) || 0) * 1000,
+    };
+
+    this.auth = updated;
+    await this.onAuthUpdate(updated);
+    this.broadcastStatus({ status: "auth_refreshed" });
+  }
+
+  async connect() {
+    if (!this.auth?.accessToken || !this.auth?.clientId) {
+      this.broadcastStatus({ status: "auth_required" });
+      return;
+    }
+
+    await this.ensureValidToken();
+    if (!this.auth?.userId) {
+      this.broadcastStatus({ status: "auth_required" });
+      return;
+    }
+
+    this.closeWs();
+    this.broadcastStatus({ status: "connecting" });
+
+    const ws = new WebSocket("wss://eventsub.wss.twitch.tv/ws");
+    this.ws = ws;
+
+    ws.addEventListener("open", () => {
+      this.connected = true;
+      this.reconnectAttempt = 0;
+      this.broadcastStatus({ status: "ws_open" });
+    });
+
+    ws.addEventListener("close", () => {
+      this.connected = false;
+      this.sessionId = null;
+      this.broadcastStatus({ status: "ws_closed" });
+      this.scheduleReconnect("ws_closed");
+    });
+
+    ws.addEventListener("error", (err) => {
+      this.broadcastStatus({ status: "ws_error", error: String(err?.message || err) });
+    });
+
+    ws.addEventListener("message", (event) => {
+      try {
+        const payload = JSON.parse(String(event.data || "{}"));
+        this.handleWsMessage(payload).catch((err) => {
+          this.broadcastStatus({ status: "error", error: String(err?.message || err) });
+        });
+      } catch (err) {
+        this.broadcastStatus({ status: "error", error: String(err?.message || err) });
+      }
+    });
+  }
+
+  async handleWsMessage(message) {
+    const messageType = message?.metadata?.message_type;
+
+    if (messageType === "session_welcome") {
+      this.sessionId = message?.payload?.session?.id || null;
+      this.broadcastStatus({ status: "session_welcome", sessionId: this.sessionId });
+      await this.createSubscriptions();
+      return;
+    }
+
+    if (messageType === "session_keepalive") return;
+
+    if (messageType === "notification") {
+      const messageId = message?.metadata?.message_id || null;
+      const subscriptionType = message?.metadata?.subscription_type || "unknown";
+      const timestamp = message?.metadata?.message_timestamp || new Date().toISOString();
+      const event = message?.payload?.event || {};
+
+      this.broadcastEvent({
+        type: "event",
+        id: messageId || createHash("sha1").update(json(message)).digest("hex"),
+        eventType: subscriptionType,
+        timestamp,
+        event,
+      });
+      return;
+    }
+
+    if (messageType === "revocation") {
+      this.broadcastStatus({
+        status: "revoked",
+        subscriptionType: message?.metadata?.subscription_type,
+        reason: message?.payload?.subscription?.status,
+      });
+      return;
+    }
+  }
+
+  async createSubscriptions() {
+    if (!this.sessionId) return;
+
+    const broadcasterUserId = this.auth?.userId;
+    if (!broadcasterUserId) return;
+
+    const subscriptions = [
+      {
+        type: "channel.channel_points_custom_reward_redemption.add",
+        version: "1",
+        condition: { broadcaster_user_id: broadcasterUserId },
+      },
+      {
+        type: "channel.raid",
+        version: "1",
+        condition: { to_broadcaster_user_id: broadcasterUserId },
+      },
+      {
+        type: "channel.raid",
+        version: "1",
+        condition: { from_broadcaster_user_id: broadcasterUserId },
+      },
+    ];
+
+    for (const sub of subscriptions) {
+      await this.createSubscription(sub).catch((err) => {
+        this.broadcastStatus({
+          status: "subscription_error",
+          subscriptionType: sub.type,
+          error: String(err?.message || err),
+        });
+      });
+    }
+  }
+
+  async createSubscription({ type, version, condition }) {
+    await this.ensureValidToken();
+
+    const res = await fetch("https://api.twitch.tv/helix/eventsub/subscriptions", {
+      method: "POST",
+      headers: {
+        "Client-Id": this.auth.clientId,
+        Authorization: `Bearer ${this.auth.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: json({
+        type,
+        version,
+        condition,
+        transport: {
+          method: "websocket",
+          session_id: this.sessionId,
+        },
+      }),
+    });
+
+    if (res.status === 409) {
+      this.broadcastStatus({ status: "subscribed", subscriptionType: type, deduped: true });
+      return;
+    }
+
+    if (!res.ok) {
+      const errText = await res.text();
+      this.broadcastStatus({
+        status: "subscription_failed",
+        subscriptionType: type,
+        httpStatus: res.status,
+        error: errText?.slice?.(0, 500) || String(errText),
+      });
+      return;
+    }
+
+    this.broadcastStatus({ status: "subscribed", subscriptionType: type });
+  }
+}
+
+class TwitchManager {
+  constructor() {
+    this.clients = new Set();
+    this.pendingStates = new Map(); // state -> { verifier, clientId, scopes, createdAt }
+    this.eventSub = new TwitchEventSub({
+      broadcastStatus: (data) => this.broadcast({ type: "status", ...data }),
+      broadcastEvent: (data) => this.broadcast(data),
+      onAuthUpdate: async (auth) => {
+        await writeJsonFile(twitchAuthFileUrl, auth);
+      },
+    });
+  }
+
+  async load() {
+    const auth = await readJsonFile(twitchAuthFileUrl);
+    if (auth?.accessToken && auth?.clientId) {
+      await this.eventSub.setAuth(auth);
+      await this.eventSub.connect();
+    }
+  }
+
+  addClient(res) {
+    this.clients.add(res);
+    this.sendTo(res, { type: "status", ...this.eventSub.getStatus() });
+  }
+
+  removeClient(res) {
+    this.clients.delete(res);
+  }
+
+  sendTo(res, data) {
+    try {
+      res.write(`data: ${json(data)}\n\n`);
+    } catch {
+      this.clients.delete(res);
+    }
+  }
+
+  broadcast(data) {
+    for (const client of this.clients) {
+      this.sendTo(client, data);
+    }
+  }
+
+  getStatus() {
+    return this.eventSub.getStatus();
+  }
+
+  async logout() {
+    this.eventSub.stop();
+    await deleteFile(twitchAuthFileUrl);
+    this.broadcast({ type: "status", status: "logged_out" });
+  }
+
+  startAuth({ clientId, scopes }) {
+    const verifier = base64Url(randomBytes(48));
+    const challenge = sha256Base64Url(verifier);
+    const state = base64Url(randomBytes(18));
+
+    this.pendingStates.set(state, {
+      verifier,
+      clientId,
+      scopes,
+      createdAt: Date.now(),
+    });
+
+    const authorize = new URL("https://id.twitch.tv/oauth2/authorize");
+    authorize.searchParams.set("response_type", "code");
+    authorize.searchParams.set("client_id", clientId);
+    authorize.searchParams.set("redirect_uri", `${oauthBaseUrl}/api/twitch/auth/callback`);
+    authorize.searchParams.set("scope", scopes.join(" "));
+    authorize.searchParams.set("state", state);
+    authorize.searchParams.set("code_challenge", challenge);
+    authorize.searchParams.set("code_challenge_method", "S256");
+
+    return authorize.toString();
+  }
+
+  async finishAuth({ code, state }) {
+    const pending = this.pendingStates.get(state);
+    if (!pending) {
+      throw new Error("invalid_state");
+    }
+    this.pendingStates.delete(state);
+
+    const body = new URLSearchParams({
+      client_id: pending.clientId,
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: `${oauthBaseUrl}/api/twitch/auth/callback`,
+      code_verifier: pending.verifier,
+    });
+
+    const res = await fetch("https://id.twitch.tv/oauth2/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`token_exchange_failed:${res.status}:${errText?.slice?.(0, 200) || ""}`);
+    }
+
+    const token = await res.json();
+    const auth = {
+      clientId: pending.clientId,
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token || null,
+      tokenType: token.token_type,
+      scope: token.scope || pending.scopes,
+      obtainedAt: Date.now(),
+      expiresAt: Date.now() + (Number(token.expires_in) || 0) * 1000,
+      userId: null,
+      login: null,
+    };
+
+    await writeJsonFile(twitchAuthFileUrl, auth);
+    await this.eventSub.setAuth(auth);
+    await this.eventSub.connect();
+    this.broadcast({ type: "status", status: "auth_ok" });
+    return this.eventSub.getStatus();
+  }
+
+  async exchangePkce({ clientId, code, codeVerifier, redirectUri }) {
+    return this.exchangePkceWithSecret({ clientId, clientSecret: null, code, codeVerifier, redirectUri });
+  }
+
+  async exchangePkceWithSecret({ clientId, clientSecret, code, codeVerifier, redirectUri }) {
+    if (!clientId || !code || !codeVerifier || !redirectUri) {
+      throw new Error("missing_required_fields");
+    }
+
+    const body = new URLSearchParams({
+      client_id: clientId,
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    });
+
+    if (clientSecret) {
+      body.set("client_secret", clientSecret);
+    }
+
+    const res = await fetch("https://id.twitch.tv/oauth2/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      if (errText?.includes?.("missing client secret")) {
+        throw new Error(
+          "token_exchange_failed:missing_client_secret (Twitch requires a client secret for this app; paste it in Settings or switch the app to a public/PKCE client if available)."
+        );
+      }
+      throw new Error(`token_exchange_failed:${res.status}:${errText?.slice?.(0, 250) || ""}`);
+    }
+
+    const token = await res.json();
+    const auth = {
+      clientId,
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token || null,
+      tokenType: token.token_type,
+      scope: token.scope || [],
+      obtainedAt: Date.now(),
+      expiresAt: Date.now() + (Number(token.expires_in) || 0) * 1000,
+      userId: null,
+      login: null,
+    };
+
+    await writeJsonFile(twitchAuthFileUrl, auth);
+    await this.eventSub.setAuth(auth);
+    await this.eventSub.connect();
+    this.broadcast({ type: "status", status: "auth_ok" });
+    return this.eventSub.getStatus();
+  }
+}
+
+class LiveRoom {
+  constructor(liveId) {
+    this.liveId = liveId;
+    this.clients = new Set();
+    this.started = false;
+    this.liveChat = new LiveChat({ liveId });
+
+    this.liveChat.on("chat", (chatItem) => {
+      const messageText = textFromChatItem(chatItem);
+      const username = chatItem?.author?.name || "Unknown";
+      const timestamp = chatItem?.timestamp
+        ? new Date(chatItem.timestamp).toISOString()
+        : new Date().toISOString();
+
+      const payload = {
+        id: stableId({
+          liveId: this.liveId,
+          username,
+          text: messageText,
+          timestamp,
+        }),
+        username,
+        text: messageText,
+        timestamp,
+      };
+
+      this.broadcast(payload);
+    });
+
+    this.liveChat.on("error", (err) => {
+      this.broadcast({ type: "error", error: String(err?.message || err) });
+    });
+
+    this.liveChat.on("end", (reason) => {
+      this.broadcast({ type: "end", reason: reason || "ended" });
+    });
+  }
+
+  async ensureStarted() {
+    if (this.started) return;
+    this.started = true;
+    const ok = await this.liveChat.start();
+    if (!ok) {
+      this.broadcast({ type: "error", error: "Failed to start YouTube chat." });
+    }
+  }
+
+  addClient(res) {
+    this.clients.add(res);
+  }
+
+  removeClient(res) {
+    this.clients.delete(res);
+    if (this.clients.size === 0) {
+      this.liveChat.stop();
+    }
+  }
+
+  broadcast(data) {
+    const line = `data: ${json(data)}\n\n`;
+    for (const client of this.clients) {
+      try {
+        client.write(line);
+      } catch {
+        this.clients.delete(client);
+      }
+    }
+  }
+}
+
+const rooms = new Map();
+
+function getRoom(liveId) {
+  const existing = rooms.get(liveId);
+  if (existing) return existing;
+  const room = new LiveRoom(liveId);
+  rooms.set(liveId, room);
+  return room;
+}
+
+const twitch = new TwitchManager();
+await twitch.load();
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+
+  if (req.method === "GET" && url.pathname === "/api/health") {
+    return send(res, 200, "ok\n", {
+      "Access-Control-Allow-Origin": "*",
+    });
+  }
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    return res.end();
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/twitch/status") {
+    return sendJson(res, 200, twitch.getStatus(), {
+      "Access-Control-Allow-Origin": "*",
+    });
+  }
+
+  if (req.method === "POST" && url.pathname === "/api/twitch/pkce/exchange") {
+    try {
+      const payload = await readJsonBody(req);
+      const clientId = String(payload?.clientId || "");
+      const clientSecret = payload?.clientSecret ? String(payload.clientSecret) : "";
+      const code = String(payload?.code || "");
+      const codeVerifier = String(payload?.codeVerifier || "");
+      const redirectUri = String(payload?.redirectUri || "");
+
+      const status = await twitch.exchangePkceWithSecret({
+        clientId,
+        clientSecret: clientSecret ? clientSecret : null,
+        code,
+        codeVerifier,
+        redirectUri,
+      });
+      return sendJson(res, 200, status, { "Access-Control-Allow-Origin": "*" });
+    } catch (err) {
+      return send(res, 400, `${String(err?.message || err)}\n`, { "Access-Control-Allow-Origin": "*" });
+    }
+  }
+
+  if ((req.method === "POST" || req.method === "GET") && url.pathname === "/api/twitch/logout") {
+    await twitch.logout();
+    return send(res, 200, "ok\n", { "Access-Control-Allow-Origin": "*" });
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/twitch/auth/start") {
+    const clientId = url.searchParams.get("clientId");
+    if (!clientId) {
+      return send(res, 400, "Missing required query param: clientId\n", {
+        "Access-Control-Allow-Origin": "*",
+      });
+    }
+
+    const scopes = ["channel:read:redemptions"];
+    const redirectTo = twitch.startAuth({ clientId, scopes });
+    res.writeHead(302, {
+      Location: redirectTo,
+      "Access-Control-Allow-Origin": "*",
+    });
+    return res.end();
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/twitch/auth/callback") {
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    if (!code || !state) {
+      return send(res, 400, "Missing required query params: code, state\n", {
+        "Access-Control-Allow-Origin": "*",
+      });
+    }
+
+    try {
+      await twitch.finishAuth({ code, state });
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+      });
+      return res.end(`<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Twitch Connected</title></head>
+  <body>
+    <script>
+      try { window.opener && window.opener.postMessage({ type: "twitch-auth", ok: true }, "*"); } catch {}
+      window.close();
+    </script>
+    Connected. You can close this tab.
+  </body>
+</html>`);
+    } catch (err) {
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+      });
+      return res.end(`<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Twitch Error</title></head>
+  <body>
+    <pre>${String(err?.message || err)}</pre>
+    <script>
+      try { window.opener && window.opener.postMessage({ type: "twitch-auth", ok: false, error: ${json(String(err?.message || err))} }, "*"); } catch {}
+    </script>
+  </body>
+</html>`);
+    }
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/twitch/sse") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.write("retry: 3000\n\n");
+
+    twitch.addClient(res);
+
+    const keepAlive = setInterval(() => {
+      try {
+        res.write(": ping\n\n");
+      } catch {
+        clearInterval(keepAlive);
+      }
+    }, 15000);
+
+    req.on("close", () => {
+      clearInterval(keepAlive);
+      twitch.removeClient(res);
+    });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/youtube/sse") {
+    const liveId = url.searchParams.get("liveId");
+    if (!liveId) {
+      return send(res, 400, "Missing required query param: liveId\n", {
+        "Access-Control-Allow-Origin": "*",
+      });
+    }
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.write("retry: 3000\n\n");
+
+    const room = getRoom(liveId);
+    room.addClient(res);
+    await room.ensureStarted();
+
+    const keepAlive = setInterval(() => {
+      try {
+        res.write(": ping\n\n");
+      } catch {
+        clearInterval(keepAlive);
+      }
+    }, 15000);
+
+    req.on("close", () => {
+      clearInterval(keepAlive);
+      room.removeClient(res);
+      if (room.clients.size === 0) {
+        rooms.delete(liveId);
+      }
+    });
+    return;
+  }
+
+  send(res, 404, "Not found\n", {
+    "Access-Control-Allow-Origin": "*",
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Proxy server listening on http://localhost:${port}`);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,9 @@
 import http from "node:http";
 import fs from "node:fs/promises";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 import { LiveChat } from "youtube-chat";
 
 const port = Number(process.env.YOUTUBE_PROXY_PORT || process.env.PORT || 4174);
-const oauthBaseUrl = `http://localhost:${port}`;
 const twitchAuthFileUrl = new URL("./.twitch-auth.json", import.meta.url);
 
 function json(data) {
@@ -41,18 +40,6 @@ async function readJsonBody(req, maxBytes = 200_000) {
   const raw = Buffer.concat(chunks).toString("utf8");
   if (!raw) return null;
   return JSON.parse(raw);
-}
-
-function base64Url(buffer) {
-  return Buffer.from(buffer)
-    .toString("base64")
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replaceAll("=", "");
-}
-
-function sha256Base64Url(input) {
-  return base64Url(createHash("sha256").update(input).digest());
 }
 
 async function readJsonFile(url) {
@@ -391,7 +378,6 @@ class TwitchEventSub {
 class TwitchManager {
   constructor() {
     this.clients = new Set();
-    this.pendingStates = new Map(); // state -> { verifier, clientId, scopes, createdAt }
     this.eventSub = new TwitchEventSub({
       broadcastStatus: (data) => this.broadcast({ type: "status", ...data }),
       broadcastEvent: (data) => this.broadcast(data),
@@ -440,76 +426,6 @@ class TwitchManager {
     this.eventSub.stop();
     await deleteFile(twitchAuthFileUrl);
     this.broadcast({ type: "status", status: "logged_out" });
-  }
-
-  startAuth({ clientId, scopes }) {
-    const verifier = base64Url(randomBytes(48));
-    const challenge = sha256Base64Url(verifier);
-    const state = base64Url(randomBytes(18));
-
-    this.pendingStates.set(state, {
-      verifier,
-      clientId,
-      scopes,
-      createdAt: Date.now(),
-    });
-
-    const authorize = new URL("https://id.twitch.tv/oauth2/authorize");
-    authorize.searchParams.set("response_type", "code");
-    authorize.searchParams.set("client_id", clientId);
-    authorize.searchParams.set("redirect_uri", `${oauthBaseUrl}/api/twitch/auth/callback`);
-    authorize.searchParams.set("scope", scopes.join(" "));
-    authorize.searchParams.set("state", state);
-    authorize.searchParams.set("code_challenge", challenge);
-    authorize.searchParams.set("code_challenge_method", "S256");
-
-    return authorize.toString();
-  }
-
-  async finishAuth({ code, state }) {
-    const pending = this.pendingStates.get(state);
-    if (!pending) {
-      throw new Error("invalid_state");
-    }
-    this.pendingStates.delete(state);
-
-    const body = new URLSearchParams({
-      client_id: pending.clientId,
-      grant_type: "authorization_code",
-      code,
-      redirect_uri: `${oauthBaseUrl}/api/twitch/auth/callback`,
-      code_verifier: pending.verifier,
-    });
-
-    const res = await fetch("https://id.twitch.tv/oauth2/token", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body,
-    });
-
-    if (!res.ok) {
-      const errText = await res.text();
-      throw new Error(`token_exchange_failed:${res.status}:${errText?.slice?.(0, 200) || ""}`);
-    }
-
-    const token = await res.json();
-    const auth = {
-      clientId: pending.clientId,
-      accessToken: token.access_token,
-      refreshToken: token.refresh_token || null,
-      tokenType: token.token_type,
-      scope: token.scope || pending.scopes,
-      obtainedAt: Date.now(),
-      expiresAt: Date.now() + (Number(token.expires_in) || 0) * 1000,
-      userId: null,
-      login: null,
-    };
-
-    await writeJsonFile(twitchAuthFileUrl, auth);
-    await this.eventSub.setAuth(auth);
-    await this.eventSub.connect();
-    this.broadcast({ type: "status", status: "auth_ok" });
-    return this.eventSub.getStatus();
   }
 
   async exchangePkce({ clientId, code, codeVerifier, redirectUri }) {
@@ -704,65 +620,13 @@ const server = http.createServer(async (req, res) => {
     return send(res, 200, "ok\n", { "Access-Control-Allow-Origin": "*" });
   }
 
-  if (req.method === "GET" && url.pathname === "/api/twitch/auth/start") {
-    const clientId = url.searchParams.get("clientId");
-    if (!clientId) {
-      return send(res, 400, "Missing required query param: clientId\n", {
-        "Access-Control-Allow-Origin": "*",
-      });
-    }
-
-    const scopes = ["channel:read:redemptions"];
-    const redirectTo = twitch.startAuth({ clientId, scopes });
-    res.writeHead(302, {
-      Location: redirectTo,
-      "Access-Control-Allow-Origin": "*",
-    });
-    return res.end();
-  }
-
-  if (req.method === "GET" && url.pathname === "/api/twitch/auth/callback") {
-    const code = url.searchParams.get("code");
-    const state = url.searchParams.get("state");
-    if (!code || !state) {
-      return send(res, 400, "Missing required query params: code, state\n", {
-        "Access-Control-Allow-Origin": "*",
-      });
-    }
-
-    try {
-      await twitch.finishAuth({ code, state });
-      res.writeHead(200, {
-        "Content-Type": "text/html; charset=utf-8",
-        "Access-Control-Allow-Origin": "*",
-      });
-      return res.end(`<!doctype html>
-<html>
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Twitch Connected</title></head>
-  <body>
-    <script>
-      try { window.opener && window.opener.postMessage({ type: "twitch-auth", ok: true }, "*"); } catch {}
-      window.close();
-    </script>
-    Connected. You can close this tab.
-  </body>
-</html>`);
-    } catch (err) {
-      res.writeHead(200, {
-        "Content-Type": "text/html; charset=utf-8",
-        "Access-Control-Allow-Origin": "*",
-      });
-      return res.end(`<!doctype html>
-<html>
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Twitch Error</title></head>
-  <body>
-    <pre>${String(err?.message || err)}</pre>
-    <script>
-      try { window.opener && window.opener.postMessage({ type: "twitch-auth", ok: false, error: ${json(String(err?.message || err))} }, "*"); } catch {}
-    </script>
-  </body>
-</html>`);
-    }
+  if (req.method === "GET" && (url.pathname === "/api/twitch/auth/start" || url.pathname === "/api/twitch/auth/callback")) {
+    return send(
+      res,
+      410,
+      "Deprecated: use the HTTPS frontend auth flow at https://localhost:5173/auth/twitch\n",
+      { "Access-Control-Allow-Origin": "*" },
+    );
   }
 
   if (req.method === "GET" && url.pathname === "/api/twitch/sse") {

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
         <i class="ri-chat-heart-fill"></i>
         <h1>Chat Aggregator</h1>
       </div>
+      <ViewerCount :viewer-counts="viewerCounts" />
       <div class="header-right">
         <button @click="showSettings = true" class="settings-toggle">
           <i class="ri-settings-3-fill"></i>
@@ -54,6 +55,7 @@
 import { mapState } from 'vuex';
 import ChatDisplay from './components/ChatDisplay.vue';
 import Settings from './components/Settings.vue';
+import ViewerCount from './components/ViewerCount.vue';
 
 const SETTINGS_STORAGE_KEY = 'chat-aggregator:settings';
 const THEME_STORAGE_KEY = 'chat-aggregator:theme';
@@ -61,7 +63,7 @@ const TWITCH_OAUTH_STORAGE_KEY = 'chat-aggregator:twitch-oauth';
 
 export default {
   name: 'App',
-  components: { ChatDisplay, Settings },
+  components: { ChatDisplay, Settings, ViewerCount },
   data() {
     return {
       isDarkTheme: false,
@@ -76,11 +78,12 @@ export default {
         twitchEventsEnabled: false,
         twitchClientId: '',
         twitchSystemName: 'CHAOSFOUNDRY // SYS',
+        twitchRequestedScopes: 'channel:read:redemptions',
       },
     };
   },
   computed: {
-    ...mapState(['messages']),
+    ...mapState(['messages', 'viewerCounts']),
   },
   watch: {
     messages: {
@@ -104,7 +107,12 @@ export default {
       const errorDescription = params.get('error_description');
 
       if (error) {
-        this.authError = `${error}${errorDescription ? `: ${errorDescription}` : ''}`;
+        const base = `${error}${errorDescription ? `: ${errorDescription}` : ''}`;
+        if (error === 'invalid_scope' || (errorDescription || '').toLowerCase().includes('invalid scope')) {
+          this.authError = `${base}\n\nFix: remove the invalid scope from Settings → Twitch Events → Requested OAuth Scopes, then Authenticate again.`;
+        } else {
+          this.authError = base;
+        }
         try {
           window.opener && window.opener.postMessage({ type: 'twitch-auth', ok: false, error: this.authError }, '*');
         } catch {
@@ -187,6 +195,7 @@ export default {
           twitchEventsEnabled: Boolean(parsed.twitchEventsEnabled),
           twitchClientId: parsed.twitchClientId || '',
           twitchSystemName: parsed.twitchSystemName || 'CHAOSFOUNDRY // SYS',
+          twitchRequestedScopes: parsed.twitchRequestedScopes || 'channel:read:redemptions',
         };
       } catch {
         return null;
@@ -207,6 +216,8 @@ export default {
         twitchEventsEnabled: Boolean(settings.twitchEventsEnabled),
         twitchClientId: settings.twitchClientId?.trim?.() || '',
         twitchSystemName: settings.twitchSystemName?.trim?.() || 'CHAOSFOUNDRY // SYS',
+        twitchRequestedScopes:
+          settings.twitchRequestedScopes?.trim?.() || 'channel:read:redemptions',
       };
       this.initialSettings = normalized;
       this.saveSettingsToStorage(normalized);
@@ -238,6 +249,7 @@ export default {
         twitchEventsEnabled: false,
         twitchClientId: '',
         twitchSystemName: 'CHAOSFOUNDRY // SYS',
+        twitchRequestedScopes: 'channel:read:redemptions',
       };
       this.initialSettings = empty;
       this.updateSettings(empty);
@@ -262,6 +274,7 @@ export default {
         twitchEventsEnabled: params.get('twitch_events') === '1' || params.get('twitch_events') === 'true',
         twitchClientId: params.get('twitch_client') || '',
         twitchSystemName: params.get('twitch_system') || '',
+        twitchRequestedScopes: params.get('twitch_scopes') || '',
         theme: params.get('theme') || '',
       };
     },
@@ -274,20 +287,24 @@ export default {
 
     const queryParams = this.parseQueryParams();
     const saved = this.loadSavedSettings();
-    const merged = {
-      twitchChannel: queryParams.twitchChannel || saved?.twitchChannel || '',
-      youtubeLiveId: queryParams.youtubeLiveId || saved?.youtubeLiveId || '',
-      kickChannel: queryParams.kickChannel || saved?.kickChannel || '',
-      twitchEventsEnabled:
-        queryParams.twitchEventsEnabled ||
-        Boolean(saved?.twitchEventsEnabled) ||
-        false,
-      twitchClientId: queryParams.twitchClientId || saved?.twitchClientId || '',
-      twitchSystemName:
-        queryParams.twitchSystemName ||
-        saved?.twitchSystemName ||
-        'CHAOSFOUNDRY // SYS',
-    };
+      const merged = {
+        twitchChannel: queryParams.twitchChannel || saved?.twitchChannel || '',
+        youtubeLiveId: queryParams.youtubeLiveId || saved?.youtubeLiveId || '',
+        kickChannel: queryParams.kickChannel || saved?.kickChannel || '',
+        twitchEventsEnabled:
+          queryParams.twitchEventsEnabled ||
+          Boolean(saved?.twitchEventsEnabled) ||
+          false,
+        twitchClientId: queryParams.twitchClientId || saved?.twitchClientId || '',
+        twitchSystemName:
+          queryParams.twitchSystemName ||
+          saved?.twitchSystemName ||
+          'CHAOSFOUNDRY // SYS',
+        twitchRequestedScopes:
+          queryParams.twitchRequestedScopes ||
+          saved?.twitchRequestedScopes ||
+          'channel:read:redemptions',
+      };
     this.initialSettings = merged;
 
     // Set theme from query parameter or system preference

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,23 +1,51 @@
 <template>
-  <div class="app-container" :class="{ 'dark-theme': isDarkTheme }">
-    <!-- <header class="app-header">
-      <i class="ri-chat-heart-fill"></i>
-      <h1>Chat Aggregator</h1>
-      <button @click="toggleTheme" class="theme-toggle">
-        <i :class="isDarkTheme ? 'ri-sun-fill' : 'ri-moon-fill'"></i>
-        {{ isDarkTheme ? 'Light Theme' : 'Dark Theme' }}
-      </button>
-    </header> -->
+  <div v-if="isAuthCallback" class="auth-callback">
+    <div class="auth-card">
+      <div class="auth-title">Connecting Twitch…</div>
+      <div class="auth-subtitle" v-if="authMessage">{{ authMessage }}</div>
+      <div class="auth-subtitle error" v-if="authError">{{ authError }}</div>
+    </div>
+  </div>
+
+  <div v-else class="app-container" :class="{ 'dark-theme': isDarkTheme }">
+    <header class="app-header">
+      <div class="header-left">
+        <i class="ri-chat-heart-fill"></i>
+        <h1>Chat Aggregator</h1>
+      </div>
+      <div class="header-right">
+        <button @click="showSettings = true" class="settings-toggle">
+          <i class="ri-settings-3-fill"></i>
+          Settings
+        </button>
+        <button @click="toggleTheme" class="theme-toggle">
+          <i :class="isDarkTheme ? 'ri-sun-fill' : 'ri-moon-fill'"></i>
+          {{ isDarkTheme ? 'Light' : 'Dark' }}
+        </button>
+      </div>
+    </header>
     <div class="main-content">
-      <aside class="settings-sidebar">
+      <main class="chat-main">
+        <ChatDisplay :messages="messages" @send-local="handleLocalSend" />
+      </main>
+    </div>
+
+    <div v-if="showSettings" class="modal-backdrop" @click.self="closeSettings">
+      <div class="modal">
         <Settings
-          @update-settings="updateSettings"
+          @update-settings="onSaveSettings"
           :initial-settings="initialSettings"
         />
-      </aside>
-      <main class="chat-main">
-        <ChatDisplay :messages="messages" />
-      </main>
+        <div class="modal-actions">
+          <button class="secondary" @click="stopAll">Stop</button>
+          <button class="secondary" @click="clearSaved">Clear Saved</button>
+          <button class="primary" @click="closeSettings">Close</button>
+        </div>
+        <p class="modal-hint">
+          Tip: You can also configure via URL, e.g.
+          <code>?twitch=channel&kick=channel&youtube_vid=VIDEO_ID</code>
+        </p>
+      </div>
     </div>
   </div>
 </template>
@@ -27,16 +55,27 @@ import { mapState } from 'vuex';
 import ChatDisplay from './components/ChatDisplay.vue';
 import Settings from './components/Settings.vue';
 
+const SETTINGS_STORAGE_KEY = 'chat-aggregator:settings';
+const THEME_STORAGE_KEY = 'chat-aggregator:theme';
+const TWITCH_OAUTH_STORAGE_KEY = 'chat-aggregator:twitch-oauth';
+
 export default {
   name: 'App',
   components: { ChatDisplay, Settings },
   data() {
     return {
       isDarkTheme: false,
+      showSettings: false,
+      isAuthCallback: false,
+      authMessage: '',
+      authError: '',
       initialSettings: {
         twitchChannel: '',
         youtubeLiveId: '',
         kickChannel: '',
+        twitchEventsEnabled: false,
+        twitchClientId: '',
+        twitchSystemName: 'CHAOSFOUNDRY // SYS',
       },
     };
   },
@@ -53,13 +92,166 @@ export default {
     },
   },
   methods: {
+    async handleTwitchAuthCallback() {
+      this.isAuthCallback = true;
+      this.authMessage = 'Finishing OAuth handshake…';
+      this.authError = '';
+
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+      const error = params.get('error');
+      const errorDescription = params.get('error_description');
+
+      if (error) {
+        this.authError = `${error}${errorDescription ? `: ${errorDescription}` : ''}`;
+        try {
+          window.opener && window.opener.postMessage({ type: 'twitch-auth', ok: false, error: this.authError }, '*');
+        } catch {
+          // ignore
+        }
+        return;
+      }
+
+      if (!code || !state) {
+        this.authError = 'Missing OAuth parameters.';
+        return;
+      }
+
+      let stored = null;
+      try {
+        stored = JSON.parse(localStorage.getItem(TWITCH_OAUTH_STORAGE_KEY) || 'null');
+      } catch {
+        stored = null;
+      }
+
+      if (!stored || stored.state !== state || !stored.codeVerifier || !stored.clientId || !stored.redirectUri) {
+        localStorage.removeItem(TWITCH_OAUTH_STORAGE_KEY);
+        this.authError = 'OAuth state mismatch (try Authenticate again).';
+        return;
+      }
+
+      this.authMessage = 'Exchanging code…';
+      try {
+        const res = await fetch('/api/twitch/pkce/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            clientId: stored.clientId,
+            clientSecret: stored.clientSecret || null,
+            code,
+            codeVerifier: stored.codeVerifier,
+            redirectUri: stored.redirectUri,
+          }),
+        });
+
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `HTTP ${res.status}`);
+        }
+
+        localStorage.removeItem(TWITCH_OAUTH_STORAGE_KEY);
+        this.authMessage = 'Connected. You can close this tab.';
+
+        try {
+          window.opener && window.opener.postMessage({ type: 'twitch-auth', ok: true }, '*');
+        } catch {
+          // ignore
+        }
+
+        try {
+          window.close();
+        } catch {
+          // ignore
+        }
+      } catch (err) {
+        localStorage.removeItem(TWITCH_OAUTH_STORAGE_KEY);
+        this.authError = String(err?.message || err);
+        try {
+          window.opener && window.opener.postMessage({ type: 'twitch-auth', ok: false, error: this.authError }, '*');
+        } catch {
+          // ignore
+        }
+      }
+    },
+    loadSavedSettings() {
+      try {
+        const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return null;
+        return {
+          twitchChannel: parsed.twitchChannel || '',
+          youtubeLiveId: parsed.youtubeLiveId || '',
+          kickChannel: parsed.kickChannel || '',
+          twitchEventsEnabled: Boolean(parsed.twitchEventsEnabled),
+          twitchClientId: parsed.twitchClientId || '',
+          twitchSystemName: parsed.twitchSystemName || 'CHAOSFOUNDRY // SYS',
+        };
+      } catch {
+        return null;
+      }
+    },
+    saveSettingsToStorage(settings) {
+      localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    },
     updateSettings(settings) {
       console.log('App.vue: Updating settings:', settings);
       this.$store.dispatch('updateSettings', settings);
     },
+    onSaveSettings(settings) {
+      const normalized = {
+        twitchChannel: settings.twitchChannel?.trim?.() || '',
+        youtubeLiveId: settings.youtubeLiveId?.trim?.() || '',
+        kickChannel: settings.kickChannel?.trim?.() || '',
+        twitchEventsEnabled: Boolean(settings.twitchEventsEnabled),
+        twitchClientId: settings.twitchClientId?.trim?.() || '',
+        twitchSystemName: settings.twitchSystemName?.trim?.() || 'CHAOSFOUNDRY // SYS',
+      };
+      this.initialSettings = normalized;
+      this.saveSettingsToStorage(normalized);
+      this.updateSettings(normalized);
+      this.showSettings = false;
+    },
+    handleLocalSend(text) {
+      const command = (text || '').trim();
+      if (!command) return;
+      if (command === '/settings') {
+        this.showSettings = true;
+        return;
+      }
+      if (command === '/clear') {
+        this.$store.commit('clearMessages');
+        return;
+      }
+      this.$store.commit('addMessage', {
+        username: 'You',
+        text: command,
+        platform: 'local',
+      });
+    },
+    stopAll() {
+      const empty = {
+        twitchChannel: '',
+        youtubeLiveId: '',
+        kickChannel: '',
+        twitchEventsEnabled: false,
+        twitchClientId: '',
+        twitchSystemName: 'CHAOSFOUNDRY // SYS',
+      };
+      this.initialSettings = empty;
+      this.updateSettings(empty);
+    },
+    clearSaved() {
+      localStorage.removeItem(SETTINGS_STORAGE_KEY);
+    },
+    closeSettings() {
+      this.showSettings = false;
+    },
     toggleTheme() {
       this.isDarkTheme = !this.isDarkTheme;
       document.documentElement.setAttribute('data-theme', this.isDarkTheme ? 'dark' : 'light');
+      localStorage.setItem(THEME_STORAGE_KEY, this.isDarkTheme ? 'dark' : 'light');
     },
     parseQueryParams() {
       const params = new URLSearchParams(window.location.search);
@@ -67,96 +259,277 @@ export default {
         twitchChannel: params.get('twitch') || '',
         youtubeLiveId: params.get('youtube_vid') || '',
         kickChannel: params.get('kick') || '',
+        twitchEventsEnabled: params.get('twitch_events') === '1' || params.get('twitch_events') === 'true',
+        twitchClientId: params.get('twitch_client') || '',
+        twitchSystemName: params.get('twitch_system') || '',
         theme: params.get('theme') || '',
       };
     },
   },
   mounted() {
+    if (window.location.pathname === '/auth/twitch') {
+      this.handleTwitchAuthCallback();
+      return;
+    }
+
     const queryParams = this.parseQueryParams();
-    this.initialSettings = {
-      twitchChannel: queryParams.twitchChannel,
-      youtubeLiveId: queryParams.youtubeLiveId,
-      kickChannel: queryParams.kickChannel,
+    const saved = this.loadSavedSettings();
+    const merged = {
+      twitchChannel: queryParams.twitchChannel || saved?.twitchChannel || '',
+      youtubeLiveId: queryParams.youtubeLiveId || saved?.youtubeLiveId || '',
+      kickChannel: queryParams.kickChannel || saved?.kickChannel || '',
+      twitchEventsEnabled:
+        queryParams.twitchEventsEnabled ||
+        Boolean(saved?.twitchEventsEnabled) ||
+        false,
+      twitchClientId: queryParams.twitchClientId || saved?.twitchClientId || '',
+      twitchSystemName:
+        queryParams.twitchSystemName ||
+        saved?.twitchSystemName ||
+        'CHAOSFOUNDRY // SYS',
     };
+    this.initialSettings = merged;
 
     // Set theme from query parameter or system preference
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    this.isDarkTheme = queryParams.theme === 'dark' || (queryParams.theme !== 'light' && prefersDark);
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    const theme =
+      queryParams.theme ||
+      savedTheme ||
+      (prefersDark ? 'dark' : 'light');
+    this.isDarkTheme = theme === 'dark';
     document.documentElement.setAttribute('data-theme', this.isDarkTheme ? 'dark' : 'light');
     console.log('App.vue: Applied theme:', this.isDarkTheme ? 'dark' : 'light');
 
-    // Auto-start services if any channel settings are provided
-    if (this.initialSettings.twitchChannel || this.initialSettings.youtubeLiveId || this.initialSettings.kickChannel) {
+    // Auto-start services if any settings are provided
+    if (
+      this.initialSettings.twitchChannel ||
+      this.initialSettings.youtubeLiveId ||
+      this.initialSettings.kickChannel ||
+      this.initialSettings.twitchEventsEnabled
+    ) {
       console.log('App.vue: Applying settings from URL:', this.initialSettings);
       this.updateSettings(this.initialSettings);
+      this.saveSettingsToStorage(this.initialSettings);
     } else {
       console.log('App.vue: No query parameters provided; waiting for settings.');
+      this.showSettings = true;
     }
   },
 };
 </script>
 
 <style scoped>
+.auth-callback {
+  height: 100%;
+  display: grid;
+  place-items: center;
+}
+.auth-card {
+  width: min(560px, 92vw);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg-strong);
+  box-shadow: var(--shadow-strong);
+  padding: 18px;
+  backdrop-filter: blur(18px) saturate(1.15);
+  -webkit-backdrop-filter: blur(18px) saturate(1.15);
+}
+.auth-title {
+  font-family: var(--font-display);
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  font-size: 1.2em;
+  margin-bottom: 8px;
+}
+.auth-subtitle {
+  color: var(--text-secondary);
+  line-height: 1.4;
+  font-size: 0.95em;
+}
+.auth-subtitle.error {
+  margin-top: 10px;
+  color: var(--accent-color);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.88em;
+  white-space: pre-wrap;
+}
+
 .app-container {
   max-width: 1200px;
+  height: 100%;
   margin: 0 auto;
-  font-family: "Inter", system-ui, sans-serif;
-  background: var(--bg-primary);
-  min-height: 100vh;
-  transition: background 0.3s ease;
+  font-family: var(--font-ui);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(18px) saturate(1.16);
+  -webkit-backdrop-filter: blur(18px) saturate(1.16);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: clamp(8px, 1.4vw, 14px);
 }
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 24px;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg-strong);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px) saturate(1.18);
+  -webkit-backdrop-filter: blur(14px) saturate(1.18);
 }
-.app-header i {
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.header-left i {
   font-size: 2em;
-  color: var(--accent-color);
-  margin-right: 12px;
+  background: linear-gradient(135deg, var(--accent-color), var(--neon-purple));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 h1 {
   font-size: 1.8em;
   color: var(--text-primary);
   margin: 0;
   flex: 1;
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
+}
+.header-right {
+  display: flex;
+  gap: 12px;
 }
 .theme-toggle {
-  background: var(--accent-color);
-  color: var(--bg-primary);
-  border: none;
-  padding: 8px 16px;
-  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(255, 122, 24, 0.92), rgba(177, 0, 255, 0.92));
+  color: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  padding: 8px 14px;
+  border-radius: 12px;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 0.9em;
   transition: background 0.2s ease;
+  box-shadow:
+    0 0 0 1px rgba(255, 122, 24, 0.18),
+    0 10px 26px rgba(0, 0, 0, 0.24),
+    0 0 28px rgba(177, 0, 255, 0.22);
 }
 .theme-toggle:hover {
-  background: var(--accent-hover);
+  filter: brightness(1.08);
 }
 .theme-toggle i {
   font-size: 1.2em;
 }
+.settings-toggle {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  border: 1px solid var(--glass-border);
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9em;
+  backdrop-filter: blur(12px) saturate(1.1);
+  -webkit-backdrop-filter: blur(12px) saturate(1.1);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.16);
+}
+.settings-toggle:hover {
+  border-color: rgba(177, 0, 255, 0.55);
+  box-shadow:
+    0 10px 26px rgba(0, 0, 0, 0.20),
+    0 0 24px rgba(255, 122, 24, 0.16);
+}
 .main-content {
   display: flex;
-}
-.settings-sidebar {
-  width: 0; /* Hidden settings UI */
-  flex-shrink: 0;
+  flex: 1;
+  min-height: 0;
 }
 .chat-main {
   flex: 1;
+  min-height: 0;
 }
 @media (max-width: 768px) {
   .main-content {
     flex-direction: column;
   }
-  .settings-sidebar {
-    width: 0;
-  }
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.52);
+  backdrop-filter: blur(10px) saturate(1.1);
+  -webkit-backdrop-filter: blur(10px) saturate(1.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 16px;
+  z-index: 1000;
+}
+.modal {
+  width: min(560px, 100%);
+  background: var(--glass-bg-strong);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  padding: 16px;
+  box-shadow:
+    0 0 0 1px rgba(177, 0, 255, 0.22),
+    0 25px 70px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px) saturate(1.15);
+  -webkit-backdrop-filter: blur(18px) saturate(1.15);
+}
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+.modal-actions button {
+  border-radius: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
+}
+.modal-actions button.primary {
+  background: linear-gradient(90deg, var(--accent-color), var(--neon-purple));
+  color: rgba(255, 255, 255, 0.96);
+  border-color: transparent;
+}
+.modal-actions button.primary:hover {
+  filter: brightness(1.08);
+}
+.modal-actions button.secondary:hover {
+  border-color: var(--accent-color);
+}
+.modal-hint {
+  margin-top: 12px;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+.modal-hint code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9em;
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
 }
 </style>

--- a/src/components/ChatDisplay.vue
+++ b/src/components/ChatDisplay.vue
@@ -1,10 +1,36 @@
 <template>
-  <div class="chat-display" ref="chatContainer">
-    <div v-for="message in messages" :key="message.id" class="message" :class="message.platform">
-      <i :class="`ri-${getIcon(message.platform)}`"></i>
-      <span class="username">{{ message.username || 'Unknown' }}</span>
-      <span class="text">{{ message.text || 'No content' }}</span>
+  <div class="chat-shell">
+    <div class="chat-messages" ref="chatContainer">
+      <div v-if="!messages.length" class="empty-state">
+        <div class="empty-title">No messages yet</div>
+        <div class="empty-subtitle">Open Settings and click Start to connect chats.</div>
+      </div>
+      <div v-for="message in messages" :key="message.id" class="message" :class="message.platform">
+        <div class="message-icon" aria-hidden="true">
+          <i :class="`ri-${getIcon(message.platform)}`"></i>
+        </div>
+        <div class="message-body">
+          <div class="message-top">
+            <span class="username">{{ message.username || 'Unknown' }}</span>
+            <span class="badge">{{ getLabel(message.platform) }}</span>
+          </div>
+          <div class="text">{{ message.text || 'No content' }}</div>
+        </div>
+      </div>
     </div>
+
+    <form class="chat-composer" @submit.prevent="submitLocalMessage">
+      <input
+        v-model="draft"
+        class="composer-input"
+        placeholder="Type a local message… (/settings, /clear)"
+        autocomplete="off"
+        aria-label="Local test message"
+      />
+      <button class="composer-send" type="submit" :disabled="!draft.trim()">
+        Send
+      </button>
+    </form>
   </div>
 </template>
 
@@ -17,6 +43,12 @@ export default {
       required: true,
     },
   },
+  emits: ['send-local'],
+  data() {
+    return {
+      draft: '',
+    };
+  },
   methods: {
     getIcon(platform) {
       switch (platform) {
@@ -26,8 +58,28 @@ export default {
           return 'youtube-fill';
         case 'kick':
           return 'kick-fill';
+        case 'system':
+          return 'cpu-fill';
+        case 'local':
+          return 'chat-1-fill';
         default:
           return 'chat-3-fill';
+      }
+    },
+    getLabel(platform) {
+      switch (platform) {
+        case 'twitch':
+          return 'Twitch';
+        case 'youtube':
+          return 'YouTube';
+        case 'kick':
+          return 'Kick';
+        case 'system':
+          return 'System';
+        case 'local':
+          return 'Local';
+        default:
+          return 'Chat';
       }
     },
     debounce(func, wait) {
@@ -42,6 +94,13 @@ export default {
       const container = this.$refs.chatContainer;
       container.scrollTop = container.scrollHeight;
       const endTime = performance.now();
+    },
+    submitLocalMessage() {
+      const text = (this.draft || '').trim();
+      if (!text) return;
+      this.$emit('send-local', text);
+      this.draft = '';
+      this.$nextTick(this.debounce(this.scrollToBottom, 50));
     },
   },
   watch: {
@@ -60,65 +119,216 @@ export default {
 </script>
 
 <style scoped>
-.chat-display {
-  min-height: 100vh;
-  overflow-y: auto;
-  background: var(--bg-secondary);
-  border-radius: 12px;
-  padding: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  scrollbar-width: thin;
-  scrollbar-color: var(--accent-color) var(--bg-secondary);
+.chat-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
 }
-.chat-display::-webkit-scrollbar {
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--glass-bg);
+  border-radius: var(--radius-xl);
+  padding: 14px;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px) saturate(1.1);
+  -webkit-backdrop-filter: blur(16px) saturate(1.1);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 122, 24, 0.85) transparent;
+  min-height: 0;
+  box-shadow:
+    inset 0 1px rgba(255, 255, 255, 0.05),
+    inset 0 -14px 38px rgba(0, 0, 0, 0.22),
+    var(--shadow-soft);
+}
+.chat-composer {
+  display: flex;
+  gap: 10px;
+  background: var(--glass-bg-strong);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  padding: 10px;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px) saturate(1.1);
+  -webkit-backdrop-filter: blur(16px) saturate(1.1);
+}
+.composer-input {
+  flex: 1;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-size: 0.95em;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+}
+.composer-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px var(--accent-shadow);
+}
+.composer-send {
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: linear-gradient(90deg, rgba(255, 122, 24, 0.92), rgba(177, 0, 255, 0.92));
+  color: rgba(255, 255, 255, 0.96);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow:
+    0 0 0 1px rgba(255, 122, 24, 0.18),
+    0 10px 24px rgba(0, 0, 0, 0.24),
+    0 0 26px rgba(177, 0, 255, 0.20);
+}
+.composer-send:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.composer-send:not(:disabled):hover {
+  filter: brightness(1.08);
+}
+.empty-state {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-xl);
+  padding: 16px;
+  border: 1px solid var(--glass-border);
+  margin-bottom: 12px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.empty-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.empty-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.95em;
+}
+.chat-messages::-webkit-scrollbar {
   width: 8px;
 }
-.chat-display::-webkit-scrollbar-thumb {
-  background: var(--accent-color);
+.chat-messages::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(255, 122, 24, 0.95), rgba(177, 0, 255, 0.95));
   border-radius: 4px;
 }
-.chat-display::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
 }
 .message {
-  display: flex;
-  align-items: center;
-  padding: 12px;
-  margin-bottom: 8px;
-  background: var(--bg-primary);
-  border-radius: 8px;
+  --platform-color: rgba(255, 122, 24, 0.95);
+  position: relative;
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 10px;
+  padding: 12px 12px 12px 14px;
+  margin-bottom: 10px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(12px) saturate(1.05);
+  -webkit-backdrop-filter: blur(12px) saturate(1.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.message::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 10px;
+  bottom: 10px;
+  width: 3px;
+  border-radius: 999px;
+  background: var(--platform-color);
+  box-shadow: 0 0 18px rgba(255, 122, 24, 0.22);
+  opacity: 0.9;
 }
 .message:hover {
   transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.09),
+    0 12px 30px rgba(0, 0, 0, 0.32),
+    0 0 28px rgba(177, 0, 255, 0.20);
 }
-.message i {
-  font-size: 1.5em;
-  margin-right: 12px;
-  color: var(--icon-color);
+.message-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  background: rgba(0, 0, 0, 0.18);
+  box-shadow:
+    inset 0 1px rgba(255, 255, 255, 0.06),
+    0 10px 20px rgba(0, 0, 0, 0.22);
 }
-.message.twitch i { color: #7b55c7; } /* Blend of Twitch purple with #2da592 */
-.message.youtube i { color: #ff4d4d; } /* Softened YouTube red */
-.message.kick i { color: #2da592; } /* Matches palette */
+.message-icon i {
+  font-size: 1.25em;
+  color: var(--platform-color);
+}
+.message.twitch { --platform-color: #9146ff; }
+.message.youtube { --platform-color: var(--accent-color); }
+.message.kick { --platform-color: var(--neon-cyan); }
+.message.local { --platform-color: rgba(255, 122, 24, 0.95); }
+.message.system { --platform-color: var(--neon-purple); }
+.message-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.message-top {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
 .username {
   font-weight: 600;
   color: var(--text-primary);
-  margin-right: 8px;
+  letter-spacing: -0.01em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .text {
-  flex: 1;
   color: var(--text-secondary);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
-.platform {
-  font-size: 0.75em;
-  color: var(--text-muted);
-  margin-left: 8px;
-  opacity: 0.7;
+.badge {
+  flex: 0 0 auto;
+  font-size: 0.72em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-display);
+  color: var(--platform-color);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 3px 8px;
+  border-radius: 999px;
+  opacity: 0.95;
 }
-.twitch { border-left: 4px solid #7b55c7; }
-.youtube { border-left: 4px solid #ff4d4d; }
-.kick { border-left: 4px solid #2da592; }
+
+@supports (color: color-mix(in srgb, white 50%, black)) {
+  .message::before {
+    box-shadow: 0 0 18px color-mix(in srgb, var(--platform-color) 40%, transparent);
+  }
+  .message:hover {
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.09),
+      0 12px 30px rgba(0, 0, 0, 0.32),
+      0 0 28px color-mix(in srgb, var(--platform-color) 26%, transparent);
+  }
+  .badge {
+    color: color-mix(in srgb, var(--platform-color) 85%, white);
+    border: 1px solid color-mix(in srgb, var(--platform-color) 42%, rgba(255, 255, 255, 0.10));
+    background: color-mix(in srgb, var(--platform-color) 14%, transparent);
+  }
+}
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -21,7 +21,7 @@
         </label>
       </div>
       <p class="hint subtle">
-        Captures channel points + raids via Twitch EventSub (requires one-time login).
+        Captures channel points via Twitch EventSub (requires one-time login). Raid alerts also appear via Twitch chat.
       </p>
       <div v-if="twitchEventsEnabled" class="events-grid">
         <div class="input-group">
@@ -35,6 +35,13 @@
         <div class="input-group">
           <label>Twitch Client Secret (if required)</label>
           <input v-model="twitchClientSecret" type="password" placeholder="Optional (kept only for this auth)" />
+        </div>
+        <div class="input-group">
+          <label>Requested OAuth Scopes</label>
+          <input
+            v-model="twitchRequestedScopes"
+            placeholder="channel:read:redemptions"
+          />
         </div>
         <div class="events-actions">
           <button class="secondary" @click="startTwitchAuth" :disabled="!twitchClientId.trim()">
@@ -100,6 +107,7 @@ export default {
         twitchEventsEnabled: false,
         twitchClientId: '',
         twitchSystemName: 'CHAOSFOUNDRY // SYS',
+        twitchRequestedScopes: 'channel:read:redemptions',
       }),
     },
   },
@@ -111,6 +119,8 @@ export default {
       twitchEventsEnabled: Boolean(this.initialSettings.twitchEventsEnabled),
       twitchClientId: this.initialSettings.twitchClientId || '',
       twitchSystemName: this.initialSettings.twitchSystemName || 'CHAOSFOUNDRY // SYS',
+      twitchRequestedScopes:
+        this.initialSettings.twitchRequestedScopes || 'channel:read:redemptions',
       twitchStatus: null,
       twitchAuthWarning: '',
       twitchClientSecret: '',
@@ -146,6 +156,8 @@ export default {
         this.twitchEventsEnabled = Boolean(newSettings.twitchEventsEnabled);
         this.twitchClientId = newSettings.twitchClientId || '';
         this.twitchSystemName = newSettings.twitchSystemName || 'CHAOSFOUNDRY // SYS';
+        this.twitchRequestedScopes =
+          newSettings.twitchRequestedScopes || 'channel:read:redemptions';
       },
       deep: true,
     },
@@ -159,6 +171,7 @@ export default {
         twitchEventsEnabled: this.twitchEventsEnabled,
         twitchClientId: this.twitchClientId,
         twitchSystemName: this.twitchSystemName,
+        twitchRequestedScopes: this.twitchRequestedScopes,
       };
       this.$emit('update-settings', settings);
     },
@@ -197,7 +210,8 @@ export default {
       }
 
       if ((this.twitchClientSecret || '').trim()) {
-        this.twitchAuthWarning = 'Client Secret is only used locally for the token exchange; it is not saved in Settings.';
+        this.twitchAuthWarning =
+          'Client Secret is only used locally (sent to your local server) and is not saved in Settings (the local server may keep it to refresh tokens).';
       }
 
       const state = this.randomBase64Url(18);
@@ -216,7 +230,8 @@ export default {
         })
       );
 
-      const scopes = ['channel:read:redemptions', 'channel:read:raids'];
+      const scopesRaw = (this.twitchRequestedScopes || '').trim();
+      const scopes = scopesRaw ? scopesRaw.split(/\s+/g).filter(Boolean) : ['channel:read:redemptions'];
       const authorize = new URL('https://id.twitch.tv/oauth2/authorize');
       authorize.searchParams.set('response_type', 'code');
       authorize.searchParams.set('client_id', clientId);

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -216,7 +216,7 @@ export default {
         })
       );
 
-      const scopes = ['channel:read:redemptions'];
+      const scopes = ['channel:read:redemptions', 'channel:read:raids'];
       const authorize = new URL('https://id.twitch.tv/oauth2/authorize');
       authorize.searchParams.set('response_type', 'code');
       authorize.searchParams.set('client_id', clientId);

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,22 +1,90 @@
 <template>
-  <!-- <div class="settings">
+  <div class="settings">
     <h2><i class="ri-settings-3-fill"></i> Settings</h2>
+    <p class="hint">
+      Enter one or more platforms and click <b>Start</b>. For YouTube without an API key, run the proxy with
+      <code>npm run server</code> (or <code>npm run dev:yt</code>).
+    </p>
     <div class="input-group">
       <label><i class="ri-twitch-fill"></i> Twitch Channel</label>
       <input v-model="twitchChannel" placeholder="Enter Twitch channel" />
     </div>
+    <div class="twitch-events">
+      <div class="section-title">
+        <div class="section-title-left">
+          <i class="ri-flashlight-fill"></i>
+          <span>Twitch Events</span>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" v-model="twitchEventsEnabled" />
+          <span class="toggle-pill" />
+        </label>
+      </div>
+      <p class="hint subtle">
+        Captures channel points + raids via Twitch EventSub (requires one-time login).
+      </p>
+      <div v-if="twitchEventsEnabled" class="events-grid">
+        <div class="input-group">
+          <label>System Name</label>
+          <input v-model="twitchSystemName" placeholder="e.g. CHAOSFOUNDRY // SYS" />
+        </div>
+        <div class="input-group">
+          <label>Twitch Client ID</label>
+          <input v-model="twitchClientId" placeholder="From dev.twitch.tv → your app" />
+        </div>
+        <div class="input-group">
+          <label>Twitch Client Secret (if required)</label>
+          <input v-model="twitchClientSecret" type="password" placeholder="Optional (kept only for this auth)" />
+        </div>
+        <div class="events-actions">
+          <button class="secondary" @click="startTwitchAuth" :disabled="!twitchClientId.trim()">
+            <i class="ri-login-circle-line"></i> Authenticate
+          </button>
+          <button class="secondary" @click="logoutTwitch" :disabled="!twitchStatus?.hasAuth">
+            <i class="ri-logout-circle-line"></i> Logout
+          </button>
+          <button class="secondary" @click="refreshTwitchStatus">
+            <i class="ri-refresh-line"></i> Status
+          </button>
+        </div>
+        <div class="events-status" v-if="twitchStatus">
+          <div class="status-row">
+            <span class="status-label">Auth</span>
+            <span class="status-value" :class="{ good: twitchStatus.hasAuth, bad: !twitchStatus.hasAuth }">
+              {{ twitchStatus.hasAuth ? 'OK' : 'Missing' }}
+            </span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Connected</span>
+            <span class="status-value" :class="{ good: twitchStatus.connected, bad: !twitchStatus.connected }">
+              {{ twitchStatus.connected ? 'Yes' : 'No' }}
+            </span>
+          </div>
+          <div class="status-row" v-if="twitchStatus.login">
+            <span class="status-label">User</span>
+            <span class="status-value">{{ twitchStatus.login }}</span>
+          </div>
+        </div>
+        <p class="hint subtle warn" v-if="twitchAuthWarning">
+          {{ twitchAuthWarning }}
+        </p>
+        <p class="hint subtle">
+          Twitch app redirect URL: <code>{{ twitchRedirectUrl }}</code>
+        </p>
+      </div>
+    </div>
     <div class="input-group">
-      <label><i class="ri-youtube-fill"></i> YouTube Video ID</label>
-      <input v-model="youtubeLiveId" placeholder="Enter YouTube video ID" />
+      <label><i class="ri-youtube-fill"></i> YouTube Live Video ID</label>
+      <input v-model="youtubeLiveId" placeholder="e.g. dQw4w9WgXcQ" />
     </div>
     <div class="input-group">
       <label><i class="ri-kick-fill"></i> Kick Channel</label>
       <input v-model="kickChannel" placeholder="Enter Kick channel" />
     </div>
-    <button @click="saveSettings" class="save-button">
-      <i class="ri-save-fill"></i> Save Settings
+    <button @click="saveSettings" class="save-button" :disabled="!hasAnyValue">
+      <i class="ri-play-fill"></i> Start
     </button>
-  </div> -->
+  </div>
 </template>
 
 <script>
@@ -29,6 +97,9 @@ export default {
         twitchChannel: '',
         youtubeLiveId: '',
         kickChannel: '',
+        twitchEventsEnabled: false,
+        twitchClientId: '',
+        twitchSystemName: 'CHAOSFOUNDRY // SYS',
       }),
     },
   },
@@ -37,20 +108,46 @@ export default {
       twitchChannel: this.initialSettings.twitchChannel,
       youtubeLiveId: this.initialSettings.youtubeLiveId,
       kickChannel: this.initialSettings.kickChannel,
+      twitchEventsEnabled: Boolean(this.initialSettings.twitchEventsEnabled),
+      twitchClientId: this.initialSettings.twitchClientId || '',
+      twitchSystemName: this.initialSettings.twitchSystemName || 'CHAOSFOUNDRY // SYS',
+      twitchStatus: null,
+      twitchAuthWarning: '',
+      twitchClientSecret: '',
     };
+  },
+  computed: {
+    twitchRedirectUrl() {
+      try {
+        if (window.location.protocol === 'https:') {
+          return new URL('/auth/twitch', window.location.origin).toString();
+        }
+        return 'https://localhost:5173/auth/twitch';
+      } catch {
+        return 'https://localhost:5173/auth/twitch';
+      }
+    },
+    hasAnyValue() {
+      return Boolean(
+        (this.twitchChannel || '').trim() ||
+          (this.youtubeLiveId || '').trim() ||
+          (this.kickChannel || '').trim() ||
+          this.twitchEventsEnabled
+      );
+    },
   },
   watch: {
     initialSettings: {
       handler(newSettings) {
         console.log('Settings.vue: Updated initialSettings:', newSettings);
-        this.twitchChannel = newSettings.twitchChannel || this.twitchChannel;
-        this.youtubeLiveId = newSettings.youtubeLiveId || this.youtubeLiveId;
-        this.kickChannel = newSettings.kickChannel || this.kickChannel;
-        // Auto-emit settings when initialSettings change
-        this.saveSettings();
+        this.twitchChannel = newSettings.twitchChannel || '';
+        this.youtubeLiveId = newSettings.youtubeLiveId || '';
+        this.kickChannel = newSettings.kickChannel || '';
+        this.twitchEventsEnabled = Boolean(newSettings.twitchEventsEnabled);
+        this.twitchClientId = newSettings.twitchClientId || '';
+        this.twitchSystemName = newSettings.twitchSystemName || 'CHAOSFOUNDRY // SYS';
       },
       deep: true,
-      immediate: true,
     },
   },
   methods: {
@@ -59,21 +156,135 @@ export default {
         twitchChannel: this.twitchChannel,
         youtubeLiveId: this.youtubeLiveId,
         kickChannel: this.kickChannel,
+        twitchEventsEnabled: this.twitchEventsEnabled,
+        twitchClientId: this.twitchClientId,
+        twitchSystemName: this.twitchSystemName,
       };
       this.$emit('update-settings', settings);
     },
+    async refreshTwitchStatus() {
+      try {
+        const res = await fetch('/api/twitch/status');
+        if (!res.ok) return;
+        this.twitchStatus = await res.json();
+      } catch {
+        // ignore
+      }
+    },
+    base64UrlFromBytes(bytes) {
+      let binary = '';
+      bytes.forEach((b) => (binary += String.fromCharCode(b)));
+      return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+    },
+    randomBase64Url(byteLength = 32) {
+      const bytes = new Uint8Array(byteLength);
+      crypto.getRandomValues(bytes);
+      return this.base64UrlFromBytes(bytes);
+    },
+    async sha256Base64Url(input) {
+      const data = new TextEncoder().encode(input);
+      const digest = await crypto.subtle.digest('SHA-256', data);
+      return this.base64UrlFromBytes(new Uint8Array(digest));
+    },
+    async startTwitchAuth() {
+      this.twitchAuthWarning = '';
+      const clientId = (this.twitchClientId || '').trim();
+      if (!clientId) return;
+
+      if (window.location.protocol !== 'https:') {
+        this.twitchAuthWarning = 'Twitch requires an HTTPS redirect URL. Start the app with `npm run dev:all:https`.';
+        return;
+      }
+
+      if ((this.twitchClientSecret || '').trim()) {
+        this.twitchAuthWarning = 'Client Secret is only used locally for the token exchange; it is not saved in Settings.';
+      }
+
+      const state = this.randomBase64Url(18);
+      const codeVerifier = this.randomBase64Url(48);
+      const codeChallenge = await this.sha256Base64Url(codeVerifier);
+      const redirectUri = new URL('/auth/twitch', window.location.origin).toString();
+
+      localStorage.setItem(
+        'chat-aggregator:twitch-oauth',
+        JSON.stringify({
+          state,
+          codeVerifier,
+          clientId,
+          clientSecret: (this.twitchClientSecret || '').trim() || null,
+          redirectUri,
+        })
+      );
+
+      const scopes = ['channel:read:redemptions'];
+      const authorize = new URL('https://id.twitch.tv/oauth2/authorize');
+      authorize.searchParams.set('response_type', 'code');
+      authorize.searchParams.set('client_id', clientId);
+      authorize.searchParams.set('redirect_uri', redirectUri);
+      authorize.searchParams.set('scope', scopes.join(' '));
+      authorize.searchParams.set('state', state);
+      authorize.searchParams.set('code_challenge', codeChallenge);
+      authorize.searchParams.set('code_challenge_method', 'S256');
+
+      window.open(authorize.toString(), 'twitch-auth', 'width=520,height=720');
+    },
+    async logoutTwitch() {
+      try {
+        await fetch('/api/twitch/logout', { method: 'POST' });
+      } catch {
+        // ignore
+      } finally {
+        await this.refreshTwitchStatus();
+      }
+    },
+  },
+  mounted() {
+    this.refreshTwitchStatus();
+    this._onAuthMessage = (event) => {
+      if (!event?.data || event.data.type !== 'twitch-auth') return;
+      this.refreshTwitchStatus();
+    };
+    window.addEventListener('message', this._onAuthMessage);
+  },
+  beforeUnmount() {
+    window.removeEventListener('message', this._onAuthMessage);
   },
 };
 </script>
 
 
-<!-- <style scoped>
+<style scoped>
 .settings {
-  background: var(--bg-secondary);
+  background: rgba(255, 255, 255, 0.04);
   padding: 16px;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  margin-bottom: 24px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px) saturate(1.1);
+  -webkit-backdrop-filter: blur(14px) saturate(1.1);
+}
+.hint {
+  margin: 8px 0 16px;
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+.hint.subtle {
+  opacity: 0.9;
+  margin-top: 10px;
+}
+.hint.subtle.warn {
+  color: var(--accent-color);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.88em;
+}
+.hint code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9em;
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
 }
 h2 {
   font-size: 1.4em;
@@ -82,10 +293,15 @@ h2 {
   display: flex;
   align-items: center;
   gap: 8px;
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
 }
 h2 i {
   font-size: 1.5em;
-  color: var(--accent-color);
+  background: linear-gradient(135deg, var(--accent-color), var(--neon-purple));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 .input-group {
   margin-bottom: 16px;
@@ -101,15 +317,15 @@ label {
 label i {
   font-size: 1.2em;
 }
-label i.ri-twitch-fill { color: #7b55c7; }
-label i.ri-youtube-fill { color: #ff4d4d; }
-label i.ri-kick-fill { color: #2da592; }
+label i.ri-twitch-fill { color: #9146ff; }
+label i.ri-youtube-fill { color: var(--accent-color); }
+label i.ri-kick-fill { color: var(--neon-cyan); }
 input {
   width: 100%;
   padding: 10px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-primary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
   color: var(--text-primary);
   font-size: 0.9em;
 }
@@ -118,23 +334,152 @@ input:focus {
   border-color: var(--accent-color);
   box-shadow: 0 0 0 2px var(--accent-shadow);
 }
+
+.twitch-events {
+  margin: 2px 0 16px;
+  padding: 12px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.section-title-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
+}
+.section-title-left i {
+  color: var(--neon-purple);
+}
+.events-grid {
+  margin-top: 10px;
+}
+.events-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+.events-actions .secondary {
+  border-radius: var(--radius-lg);
+  padding: 10px 12px;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
+}
+.events-actions .secondary:hover {
+  border-color: rgba(177, 0, 255, 0.55);
+}
+.events-actions .secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.events-status {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  background: rgba(0, 0, 0, 0.14);
+}
+.status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 2px;
+}
+.status-label {
+  color: var(--text-secondary);
+  font-size: 0.9em;
+}
+.status-value {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.status-value.good {
+  color: var(--neon-cyan);
+}
+.status-value.bad {
+  color: var(--accent-color);
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle input {
+  display: none;
+}
+.toggle-pill {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: rgba(0, 0, 0, 0.18);
+  position: relative;
+  transition: background 0.18s ease, border-color 0.18s ease;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.08);
+}
+.toggle-pill::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.86);
+  transition: left 0.18s ease;
+}
+.toggle input:checked + .toggle-pill {
+  border-color: rgba(255, 122, 24, 0.55);
+  background: rgba(177, 0, 255, 0.20);
+}
+.toggle input:checked + .toggle-pill::after {
+  left: 23px;
+  background: rgba(255, 122, 24, 0.92);
+}
 .save-button {
-  background: var(--accent-color);
-  color: var(--bg-primary);
+  background: linear-gradient(90deg, rgba(255, 122, 24, 0.92), rgba(177, 0, 255, 0.92));
+  color: rgba(255, 255, 255, 0.96);
   border: none;
   padding: 10px 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 0.9em;
   transition: background 0.2s ease;
+  box-shadow:
+    0 0 0 1px rgba(255, 122, 24, 0.18),
+    0 10px 22px rgba(0, 0, 0, 0.22);
 }
 .save-button:hover {
-  background: var(--accent-hover);
+  filter: brightness(1.08);
+}
+.save-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  filter: none;
 }
 .save-button i {
   font-size: 1.2em;
 }
-</style> -->
+</style>

--- a/src/components/ViewerCount.vue
+++ b/src/components/ViewerCount.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="viewer-counts" v-if="hasAnyCount">
+    <div
+      v-for="platform in activePlatforms"
+      :key="platform.key"
+      class="viewer-item"
+      :class="platform.key"
+    >
+      <i :class="`ri-${platform.icon}`"></i>
+      <span class="count">{{ formatCount(platform.count) }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ViewerCount',
+  props: {
+    viewerCounts: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    activePlatforms() {
+      const platforms = [];
+      if (this.viewerCounts.twitch !== null) {
+        platforms.push({
+          key: 'twitch',
+          icon: 'twitch-fill',
+          count: this.viewerCounts.twitch,
+        });
+      }
+      if (this.viewerCounts.youtube !== null) {
+        platforms.push({
+          key: 'youtube',
+          icon: 'youtube-fill',
+          count: this.viewerCounts.youtube,
+        });
+      }
+      if (this.viewerCounts.kick !== null) {
+        platforms.push({
+          key: 'kick',
+          icon: 'eye-fill',
+          count: this.viewerCounts.kick,
+        });
+      }
+      return platforms;
+    },
+    hasAnyCount() {
+      return this.activePlatforms.length > 0;
+    },
+  },
+  methods: {
+    formatCount(count) {
+      if (count === null || count === undefined) return '--';
+      if (count >= 1000000) {
+        return (count / 1000000).toFixed(1) + 'M';
+      }
+      if (count >= 1000) {
+        return (count / 1000).toFixed(1) + 'K';
+      }
+      return count.toLocaleString();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.viewer-counts {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.viewer-item {
+  --platform-color: var(--accent-color);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  font-size: 0.85em;
+  font-weight: 600;
+  color: var(--text-primary);
+  transition: all 0.2s ease;
+}
+
+.viewer-item:hover {
+  border-color: var(--platform-color);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--platform-color) 30%, transparent);
+}
+
+.viewer-item i {
+  font-size: 1.1em;
+  color: var(--platform-color);
+}
+
+.viewer-item.twitch {
+  --platform-color: #9146ff;
+}
+
+.viewer-item.youtube {
+  --platform-color: #ff0000;
+}
+
+.viewer-item.kick {
+  --platform-color: #53fc18;
+}
+
+.count {
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
+}
+
+@media (max-width: 480px) {
+  .viewer-counts {
+    gap: 4px;
+  }
+  .viewer-item {
+    padding: 4px 8px;
+    font-size: 0.8em;
+  }
+}
+</style>

--- a/src/services/kickService.js
+++ b/src/services/kickService.js
@@ -6,6 +6,8 @@ export default class KickService {
     this.channelId = channelId;
     this.onMessage = onMessage;
     this.pollingInterval = null;
+    this.seenMessageIds = new Set();
+    this.seenQueue = [];
   }
 
   start() {
@@ -30,11 +32,25 @@ export default class KickService {
       }
 
       messages.forEach((msg) => {
+        const rawId = msg?.id ?? null;
+        const id = rawId === null || rawId === undefined ? null : String(rawId);
+        if (id && this.seenMessageIds.has(id)) return;
+        if (id) {
+          this.seenMessageIds.add(id);
+          this.seenQueue.push(id);
+          if (this.seenQueue.length > 2000) {
+            const oldest = this.seenQueue.shift();
+            if (oldest) this.seenMessageIds.delete(oldest);
+          }
+        }
+
+        const createdAt = msg?.created_at || msg?.createdAt || msg?.timestamp || null;
         const message = {
-          id: msg.id || uuidv4(),
+          id: id || uuidv4(),
           username: msg.sender?.username || msg.sender?.name || "Unknown",
           text: msg.content || msg.message || "No content",
           platform: "kick",
+          timestamp: createdAt,
         };
         this.onMessage(message);
       });
@@ -51,5 +67,7 @@ export default class KickService {
       clearInterval(this.pollingInterval);
       this.pollingInterval = null;
     }
+    this.seenMessageIds.clear();
+    this.seenQueue = [];
   }
 }

--- a/src/services/twitchEventProxyService.js
+++ b/src/services/twitchEventProxyService.js
@@ -1,0 +1,120 @@
+export default class TwitchEventProxyService {
+  constructor(options, onMessage) {
+    const { systemName = "CHAOSFOUNDRY // SYS" } = options || {};
+    this.systemName = systemName;
+    this.onMessage = onMessage;
+    this.eventSource = null;
+    this.sentConnectError = false;
+  }
+
+  start() {
+    this.sentConnectError = false;
+    this.eventSource = new EventSource("/api/twitch/sse");
+
+    this.eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        this.handlePayload(data);
+      } catch (err) {
+        // ignore
+      }
+    };
+
+    this.eventSource.onerror = () => {
+      if (this.sentConnectError) return;
+      this.sentConnectError = true;
+      this.onMessage({
+        id: `twitch-events:connect-error:${Date.now()}`,
+        username: this.systemName,
+        text: "Twitch Events: can't reach the local server. Start it with `npm run server` (or `npm run dev:yt`).",
+      });
+    };
+  }
+
+  stop() {
+    try {
+      this.eventSource?.close?.();
+    } catch {
+      // ignore
+    }
+    this.eventSource = null;
+  }
+
+  handlePayload(payload) {
+    if (!payload || typeof payload !== "object") return;
+
+    if (payload.type === "event") {
+      const { id, eventType, event, timestamp } = payload;
+      const text = this.formatEvent(eventType, event);
+      if (!text) return;
+
+      this.onMessage({
+        id: id || `twitch-event:${eventType}:${timestamp || Date.now()}`,
+        username: this.systemName,
+        text,
+        timestamp,
+        meta: { eventType },
+      });
+      return;
+    }
+
+    if (payload.type === "status") {
+      const maybeText = this.formatStatus(payload);
+      if (!maybeText) return;
+      this.onMessage({
+        id: `twitch-status:${payload.status || "unknown"}:${Date.now()}`,
+        username: this.systemName,
+        text: maybeText,
+      });
+    }
+  }
+
+  formatEvent(eventType, event) {
+    if (!eventType) return null;
+
+    if (eventType === "channel.channel_points_custom_reward_redemption.add") {
+      const user = event?.user_name || "Someone";
+      const title = event?.reward?.title || "Channel Points";
+      const input = (event?.user_input || "").trim();
+      if (input) return `REWARD REDEEMED — ${user}: “${title}” — ${input}`;
+      return `REWARD REDEEMED — ${user}: “${title}”`;
+    }
+
+    if (eventType === "channel.raid") {
+      const from = event?.from_broadcaster_user_name;
+      const to = event?.to_broadcaster_user_name;
+      const viewers = Number(event?.viewers || 0);
+      if (from && to) {
+        return `RAID — ${from} → ${to} (${viewers} viewers)`;
+      }
+      if (from) return `RAID INBOUND — ${from} (${viewers} viewers)`;
+      if (to) return `RAID OUTBOUND — → ${to} (${viewers} viewers)`;
+      return `RAID (${viewers} viewers)`;
+    }
+
+    return `TWITCH EVENT — ${eventType}`;
+  }
+
+  formatStatus(status) {
+    const s = status?.status;
+    if (!s) return null;
+
+    if (s === "auth_required") return "Twitch Events: not authenticated yet. Open Settings → Authenticate.";
+    if (s === "auth_invalid") return "Twitch Events: auth expired/invalid. Re-authenticate in Settings.";
+    if (s === "auth_refresh_failed") return "Twitch Events: token refresh failed. Re-authenticate in Settings.";
+    if (s === "auth_ok") return "Twitch Events: authenticated.";
+    if (s === "ws_open") {
+      const login = status?.login ? ` as ${status.login}` : "";
+      return `Twitch Events connected${login}.`;
+    }
+    if (s === "subscription_failed") {
+      const type = status?.subscriptionType || "unknown";
+      return `Twitch Events: failed to subscribe to ${type}.`;
+    }
+    if (s === "revoked") return "Twitch Events: subscription revoked.";
+    if (s === "logged_out") return "Twitch Events: logged out.";
+
+    return null;
+  }
+}
+

--- a/src/services/twitchEventProxyService.js
+++ b/src/services/twitchEventProxyService.js
@@ -107,6 +107,11 @@ export default class TwitchEventProxyService {
       const login = status?.login ? ` as ${status.login}` : "";
       return `Twitch Events connected${login}.`;
     }
+    if (s === "subscription_skipped") {
+      const type = status?.subscriptionType || "unknown";
+      const reason = status?.reason || "skipped";
+      return `Twitch Events: skipping ${type} (${reason}).`;
+    }
     if (s === "subscription_failed") {
       const type = status?.subscriptionType || "unknown";
       return `Twitch Events: failed to subscribe to ${type}.`;
@@ -117,4 +122,3 @@ export default class TwitchEventProxyService {
     return null;
   }
 }
-

--- a/src/services/twitchService.js
+++ b/src/services/twitchService.js
@@ -7,9 +7,34 @@ export default class TwitchService {
     });
     this.onMessage = onMessage;
     this.client.on('message', (channel, tags, message, self) => {
+      const sentTs = tags?.['tmi-sent-ts'] ? Number(tags['tmi-sent-ts']) : null;
       this.onMessage({
-        username: tags['display-name'],
+        username: tags?.['display-name'] || tags?.username || 'Unknown',
         text: message,
+        timestamp: Number.isFinite(sentTs) ? sentTs : null,
+      });
+    });
+
+    this.client.on('raided', (channel, username, viewers) => {
+      const raider = username || 'Someone';
+      const count = Number(viewers || 0);
+      this.onMessage({
+        username: raider,
+        text: `RAID — ${count} viewers`,
+        timestamp: Date.now(),
+        meta: { eventType: 'raid', viewers: count },
+      });
+    });
+
+    this.client.on('hosted', (channel, username, viewers, autohost) => {
+      const host = username || 'Someone';
+      const count = Number(viewers || 0);
+      const mode = autohost ? 'AUTOHOST' : 'HOST';
+      this.onMessage({
+        username: host,
+        text: `${mode} — ${count} viewers`,
+        timestamp: Date.now(),
+        meta: { eventType: 'host', viewers: count, autohost: Boolean(autohost) },
       });
     });
   }

--- a/src/services/youtubeProxyService.js
+++ b/src/services/youtubeProxyService.js
@@ -1,0 +1,58 @@
+function joinUrl(base, path) {
+  if (!base) return path;
+  const trimmedBase = base.replace(/\/+$/, "");
+  const trimmedPath = path.replace(/^\/+/, "");
+  return `${trimmedBase}/${trimmedPath}`;
+}
+
+export default class YoutubeProxyService {
+  constructor(liveId, onMessage) {
+    this.liveId = liveId;
+    this.onMessage = onMessage;
+    this.eventSource = null;
+    this.seenMessageIds = new Set();
+  }
+
+  start() {
+    if (this.eventSource) return;
+
+    const baseUrl = import.meta.env.VITE_YOUTUBE_PROXY_URL || "";
+    const url = joinUrl(
+      baseUrl,
+      `/api/youtube/sse?liveId=${encodeURIComponent(this.liveId)}`
+    );
+
+    this.eventSource = new EventSource(url);
+    this.eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data?.type) return; // ignore status/error messages
+        if (data?.id && this.seenMessageIds.has(data.id)) return;
+        if (data?.id) this.seenMessageIds.add(data.id);
+
+        this.onMessage({
+          id: data?.id,
+          username: data?.username,
+          text: data?.text,
+        });
+
+        if (this.seenMessageIds.size > 2000) {
+          const ids = Array.from(this.seenMessageIds);
+          this.seenMessageIds = new Set(ids.slice(-2000));
+        }
+      } catch (err) {
+        console.error("YouTube Proxy Parse Error:", err);
+      }
+    };
+    this.eventSource.onerror = (err) => {
+      console.error("YouTube Proxy Error:", err);
+    };
+  }
+
+  stop() {
+    this.eventSource?.close?.();
+    this.eventSource = null;
+    this.seenMessageIds.clear();
+  }
+}
+

--- a/src/services/youtubeProxyService.js
+++ b/src/services/youtubeProxyService.js
@@ -34,6 +34,7 @@ export default class YoutubeProxyService {
           id: data?.id,
           username: data?.username,
           text: data?.text,
+          timestamp: data?.timestamp || null,
         });
 
         if (this.seenMessageIds.size > 2000) {
@@ -55,4 +56,3 @@ export default class YoutubeProxyService {
     this.seenMessageIds.clear();
   }
 }
-

--- a/src/services/youtubeService.js
+++ b/src/services/youtubeService.js
@@ -36,6 +36,7 @@ export default class YoutubeService {
             username: item.authorDetails.displayName,
             text: item.snippet.displayMessage,
             id: item.id, // Use YouTube's message ID for deduplication
+            timestamp: item.snippet?.publishedAt || null,
           });
         }
       });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,20 @@ import TwitchEventProxyService from "../services/twitchEventProxyService";
 import YoutubeService from "../services/youtubeService";
 import YoutubeProxyService from "../services/youtubeProxyService";
 
+function timestampMs(value) {
+  if (!value) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const ms = Date.parse(value);
+    return Number.isFinite(ms) ? ms : null;
+  }
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return null;
+}
+
 async function getLiveChatId(videoId, apiKey) {
   try {
     const response = await axios.get(
@@ -47,6 +61,24 @@ async function getKickChannelId(channelName) {
   }
 }
 
+async function fetchTwitchViewerCount(channel) {
+  try {
+    const response = await axios.get(`/api/viewers/twitch/${channel}`);
+    return response.data?.viewers ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchKickViewerCount(channel) {
+  try {
+    const response = await axios.get(`/api/viewers/kick/${channel}`);
+    return response.data?.viewers ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export default createStore({
   state: {
     messages: [],
@@ -57,6 +89,7 @@ export default createStore({
       twitchEventsEnabled: false,
       twitchClientId: "",
       twitchSystemName: "CHAOSFOUNDRY // SYS",
+      twitchRequestedScopes: "channel:read:redemptions",
     },
     services: {
       twitch: null,
@@ -64,11 +97,27 @@ export default createStore({
       kick: null,
       twitchEvents: null,
     },
+    viewerCounts: {
+      twitch: null,
+      youtube: null,
+      kick: null,
+    },
+    viewerCountPoller: null,
     messageIds: new Set(),
     maxMessages: 100,
+    clearCutoffMs: 0,
   },
   mutations: {
     addMessage(state, message) {
+      const cutoff = Number(state.clearCutoffMs || 0);
+      if (cutoff) {
+        const msgTime =
+          timestampMs(message?.timestamp) ??
+          timestampMs(message?.meta?.timestamp) ??
+          timestampMs(message?.meta?.timestampMs);
+        if (msgTime !== null && msgTime < cutoff) return;
+      }
+
       const messageId = message.id || uuidv4();
       if (!state.messageIds.has(messageId)) {
         state.messageIds.add(messageId);
@@ -89,17 +138,41 @@ export default createStore({
     clearMessages(state) {
       state.messages = [];
       state.messageIds.clear();
+      state.clearCutoffMs = Date.now();
+    },
+    setViewerCount(state, { platform, count }) {
+      state.viewerCounts[platform] = count;
+    },
+    clearViewerCounts(state) {
+      state.viewerCounts = { twitch: null, youtube: null, kick: null };
+    },
+    setViewerCountPoller(state, poller) {
+      if (state.viewerCountPoller) {
+        clearInterval(state.viewerCountPoller);
+      }
+      state.viewerCountPoller = poller;
     },
   },
   actions: {
     async updateSettings({ commit, state }, settings) {
       Object.values(state.services).forEach((service) => service?.stop?.());
       commit("clearMessages");
+      commit("clearViewerCounts");
+      commit("setViewerCountPoller", null);
 
       const twitch = settings.twitchChannel
-        ? new TwitchService(settings.twitchChannel, (message) =>
-            commit("addMessage", { ...message, platform: "twitch" })
-          )
+        ? new TwitchService(settings.twitchChannel, (message) => {
+            const isAlert = message?.meta?.eventType === "raid" || message?.meta?.eventType === "host";
+            if (isAlert) {
+              commit("addMessage", {
+                ...message,
+                username: settings.twitchSystemName || "CHAOSFOUNDRY // SYS",
+                platform: "system",
+              });
+              return;
+            }
+            commit("addMessage", { ...message, platform: "twitch" });
+          })
         : null;
 
       const twitchEvents = settings.twitchEventsEnabled
@@ -150,6 +223,25 @@ export default createStore({
       commit("setService", { platform: "youtube", service: youtube });
       commit("setService", { platform: "kick", service: kick });
       commit("setService", { platform: "twitchEvents", service: twitchEvents });
+
+      // Start viewer count polling if any platform is enabled (YouTube excluded - no ToS-compliant free API)
+      const hasAnyPlatform = settings.twitchChannel || settings.kickChannel;
+      if (hasAnyPlatform) {
+        const fetchViewerCounts = async () => {
+          if (settings.twitchChannel) {
+            const count = await fetchTwitchViewerCount(settings.twitchChannel);
+            commit("setViewerCount", { platform: "twitch", count });
+          }
+          if (settings.kickChannel) {
+            const count = await fetchKickViewerCount(settings.kickChannel);
+            commit("setViewerCount", { platform: "kick", count });
+          }
+        };
+        // Fetch immediately, then poll every 30 seconds
+        fetchViewerCounts();
+        const poller = setInterval(fetchViewerCounts, 30000);
+        commit("setViewerCountPoller", poller);
+      }
     },
   },
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,7 +3,9 @@ import { v4 as uuidv4 } from "uuid";
 import { createStore } from "vuex";
 import KickService from "../services/kickService";
 import TwitchService from "../services/twitchService";
+import TwitchEventProxyService from "../services/twitchEventProxyService";
 import YoutubeService from "../services/youtubeService";
+import YoutubeProxyService from "../services/youtubeProxyService";
 
 async function getLiveChatId(videoId, apiKey) {
   try {
@@ -52,11 +54,15 @@ export default createStore({
       twitchChannel: "",
       youtubeLiveId: "",
       kickChannel: "",
+      twitchEventsEnabled: false,
+      twitchClientId: "",
+      twitchSystemName: "CHAOSFOUNDRY // SYS",
     },
     services: {
       twitch: null,
       youtube: null,
       kick: null,
+      twitchEvents: null,
     },
     messageIds: new Set(),
     maxMessages: 100,
@@ -96,16 +102,29 @@ export default createStore({
           )
         : null;
 
+      const twitchEvents = settings.twitchEventsEnabled
+        ? new TwitchEventProxyService(
+            { systemName: settings.twitchSystemName },
+            (message) => commit("addMessage", { ...message, platform: "system" })
+          )
+        : null;
+
       let youtube = null;
       if (settings.youtubeLiveId) {
         const apiKey = import.meta.env.VITE_YOUTUBE_API_KEY;
-        const liveChatId = await getLiveChatId(settings.youtubeLiveId, apiKey);
-        if (liveChatId) {
-          youtube = new YoutubeService(liveChatId, (message) =>
+        if (apiKey) {
+          const liveChatId = await getLiveChatId(settings.youtubeLiveId, apiKey);
+          if (liveChatId) {
+            youtube = new YoutubeService(liveChatId, (message) =>
+              commit("addMessage", { ...message, platform: "youtube" })
+            );
+          } else {
+            console.error("Failed to retrieve valid liveChatId.");
+          }
+        } else {
+          youtube = new YoutubeProxyService(settings.youtubeLiveId, (message) =>
             commit("addMessage", { ...message, platform: "youtube" })
           );
-        } else {
-          console.error("Failed to retrieve valid liveChatId.");
         }
       }
 
@@ -122,6 +141,7 @@ export default createStore({
       }
 
       twitch?.start();
+      twitchEvents?.start();
       youtube?.start();
       kick?.start();
 
@@ -129,6 +149,7 @@ export default createStore({
       commit("setService", { platform: "twitch", service: twitch });
       commit("setService", { platform: "youtube", service: youtube });
       commit("setService", { platform: "kick", service: kick });
+      commit("setService", { platform: "twitchEvents", service: twitchEvents });
     },
   },
 });

--- a/src/style.css
+++ b/src/style.css
@@ -1,29 +1,69 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 :root {
-  --bg-primary: #f5faf6;
-  --bg-secondary: #8bcbb7;
-  --text-primary: #123a49;
-  --text-secondary: #4a4a4a;
-  --text-muted: #6b7280;
-  --accent-color: #2da592;
-  --accent-hover: #248f7d;
-  --accent-shadow: rgba(45, 165, 146, 0.2);
-  --border-color: #d1d5db;
-  --icon-color: #123a49;
+  --font-ui: "Vandav", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --font-display: "Pirulen", "Vandav", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --bg-primary: #f8f5ff;
+  --bg-secondary: #efe7ff;
+  --text-primary: #1a0b2e;
+  --text-secondary: #3b2b52;
+  --text-muted: #6b5b86;
+  --accent-color: #ff7a18;
+  --accent-hover: #ff933d;
+  --accent-shadow: rgba(255, 122, 24, 0.35);
+  --border-color: rgba(26, 11, 46, 0.16);
+  --icon-color: #1a0b2e;
+  --neon-purple: #b100ff;
+  --neon-cyan: #00f5ff;
+  --radius-xl: 18px;
+  --radius-lg: 14px;
+  --radius-md: 12px;
+  --radius-sm: 10px;
+  --glass-bg: rgba(255, 255, 255, 0.65);
+  --glass-bg-strong: rgba(255, 255, 255, 0.78);
+  --glass-border: rgba(26, 11, 46, 0.18);
+  --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.12);
+  --shadow-strong: 0 22px 70px rgba(0, 0, 0, 0.24);
+  --focus-ring: 0 0 0 2px rgba(255, 122, 24, 0.24), 0 0 0 6px rgba(177, 0, 255, 0.12);
+}
+
+@font-face {
+  font-family: "Pirulen";
+  src:
+    local("Pirulen"),
+    url("/fonts/PirulenRg.otf") format("opentype");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Vandav";
+  src:
+    local("Vandav"),
+    url("/fonts/Vandav.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
 }
 
 [data-theme='dark'] {
-  --bg-primary: #123a49;
-  --bg-secondary: #2da592;
-  --text-primary: #f5faf6;
-  --text-secondary: #8bcbb7;
-  --text-muted: #9ca3af;
-  --accent-color: #2da592;
-  --accent-hover: #3cb7a1;
-  --accent-shadow: rgba(45, 165, 146, 0.2);
-  --border-color: #4b5563;
-  --icon-color: #f5faf6;
+  --bg-primary: #07020f;
+  --bg-secondary: #120624;
+  --text-primary: #f6efff;
+  --text-secondary: #d7ccff;
+  --text-muted: #ad9fd6;
+  --accent-color: #ff7a18;
+  --accent-hover: #ff933d;
+  --accent-shadow: rgba(255, 122, 24, 0.35);
+  --border-color: rgba(177, 0, 255, 0.35);
+  --icon-color: #f6efff;
+  --neon-purple: #b100ff;
+  --neon-cyan: #00f5ff;
+  --glass-bg: rgba(18, 6, 36, 0.62);
+  --glass-bg-strong: rgba(18, 6, 36, 0.78);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --shadow-soft: 0 14px 34px rgba(0, 0, 0, 0.35);
+  --shadow-strong: 0 26px 80px rgba(0, 0, 0, 0.55);
+  --focus-ring: 0 0 0 2px rgba(255, 122, 24, 0.22), 0 0 0 6px rgba(177, 0, 255, 0.18);
 }
 
 * {
@@ -32,8 +72,62 @@
   box-sizing: border-box;
 }
 
+html,
+body,
+#app {
+  height: 100%;
+}
+
 body {
-  font-family: 'Inter', system-ui, sans-serif;
-  background: var(--bg-primary);
+  font-family: var(--font-ui);
+  background:
+    radial-gradient(900px circle at 20% 0%, rgba(177, 0, 255, 0.22), transparent 56%),
+    radial-gradient(900px circle at 80% 0%, rgba(255, 122, 24, 0.20), transparent 56%),
+    radial-gradient(1100px circle at 50% 120%, rgba(0, 245, 255, 0.10), transparent 60%),
+    var(--bg-primary);
   color: var(--text-primary);
+  padding: clamp(6px, 1.2vw, 12px);
+  overflow: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.08;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.06) 0px,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px,
+      transparent 4px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.045) 0px,
+      rgba(255, 255, 255, 0.045) 1px,
+      transparent 1px,
+      transparent 6px
+    );
+  mix-blend-mode: overlay;
+}
+
+::selection {
+  background: rgba(255, 122, 24, 0.28);
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,19 @@
 import vue from "@vitejs/plugin-vue";
+import basicSsl from "@vitejs/plugin-basic-ssl";
 import { defineConfig } from "vite";
 
+const useHttps = process.env.HTTPS === "1" || process.env.VITE_HTTPS === "1";
+
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), useHttps ? basicSsl() : null].filter(Boolean),
+  server: {
+    https: useHttps,
+    proxy: {
+      "/api": {
+        target: `http://localhost:${process.env.YOUTUBE_PROXY_PORT || 4174}`,
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
So basically this just lets you see Twitch events like raids, cheers, channel point redeems using a Twitch API endpoint you generate via Twitch Dev at: 
``` https://dev.twitch.tv/console ``` and logging in with your twitch, registering an app -> then making a name, using the endpoint you get in settings after running 
``` cd <the directory you choose> && npm install ```
``` npm run dev:all:https #Twitch needs this for https redirect in dev console```
Then you go to the local host it generates, accept the cert warning (need help fixing this in later PR?) and then you'll have Twitch events after you ender ``` Twitch Client ID and Twitch Secret if like me you accidentally added one ``` 
use endpoint ```  https://localhost:5173/auth/twitch ```